### PR TITLE
Configura solução FridaHub com projetos base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Build outputs
+bin/
+obj/

--- a/FridaHub.sln
+++ b/FridaHub.sln
@@ -1,0 +1,55 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{DC46D3D9-71A0-478C-BFE0-40A3062AB29A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FridaHub.App", "src\FridaHub.App\FridaHub.App.csproj", "{41A90419-F9E2-4362-A51B-700C3BE7632C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FridaHub.Core", "src\FridaHub.Core\FridaHub.Core.csproj", "{8402AAB4-DCA7-430C-BB42-43CC6966428F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FridaHub.Infrastructure", "src\FridaHub.Infrastructure\FridaHub.Infrastructure.csproj", "{8008D25A-CF0F-4902-8B9B-A5C88FDA12F7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FridaHub.Processes", "src\FridaHub.Processes\FridaHub.Processes.csproj", "{2F1829D7-D13D-4AE4-B215-4AC3F0A4200C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FridaHub.Codeshare", "src\FridaHub.Codeshare\FridaHub.Codeshare.csproj", "{232D0A72-C778-4451-A66C-10A13E20B135}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{41A90419-F9E2-4362-A51B-700C3BE7632C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41A90419-F9E2-4362-A51B-700C3BE7632C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41A90419-F9E2-4362-A51B-700C3BE7632C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41A90419-F9E2-4362-A51B-700C3BE7632C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8402AAB4-DCA7-430C-BB42-43CC6966428F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8402AAB4-DCA7-430C-BB42-43CC6966428F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8402AAB4-DCA7-430C-BB42-43CC6966428F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8402AAB4-DCA7-430C-BB42-43CC6966428F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8008D25A-CF0F-4902-8B9B-A5C88FDA12F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8008D25A-CF0F-4902-8B9B-A5C88FDA12F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8008D25A-CF0F-4902-8B9B-A5C88FDA12F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8008D25A-CF0F-4902-8B9B-A5C88FDA12F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F1829D7-D13D-4AE4-B215-4AC3F0A4200C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F1829D7-D13D-4AE4-B215-4AC3F0A4200C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F1829D7-D13D-4AE4-B215-4AC3F0A4200C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F1829D7-D13D-4AE4-B215-4AC3F0A4200C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{232D0A72-C778-4451-A66C-10A13E20B135}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{232D0A72-C778-4451-A66C-10A13E20B135}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{232D0A72-C778-4451-A66C-10A13E20B135}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{232D0A72-C778-4451-A66C-10A13E20B135}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{41A90419-F9E2-4362-A51B-700C3BE7632C} = {DC46D3D9-71A0-478C-BFE0-40A3062AB29A}
+		{8402AAB4-DCA7-430C-BB42-43CC6966428F} = {DC46D3D9-71A0-478C-BFE0-40A3062AB29A}
+		{8008D25A-CF0F-4902-8B9B-A5C88FDA12F7} = {DC46D3D9-71A0-478C-BFE0-40A3062AB29A}
+		{2F1829D7-D13D-4AE4-B215-4AC3F0A4200C} = {DC46D3D9-71A0-478C-BFE0-40A3062AB29A}
+		{232D0A72-C778-4451-A66C-10A13E20B135} = {DC46D3D9-71A0-478C-BFE0-40A3062AB29A}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# FridaDesk
+# FridaHub
+
+Solução inicial contendo os projetos base para o aplicativo Avalonia.
+
+## Estrutura
+- **FridaHub.App**: aplicativo Avalonia.
+- **FridaHub.Core**: biblioteca de classes principal.
+- **FridaHub.Infrastructure**: acesso a dados e configurações.
+- **FridaHub.Processes**: processos de negócio.
+- **FridaHub.Codeshare**: componentes compartilhados.
+
+## Como compilar
+```bash
+dotnet build
+```
+
+## Autor
+Pexe — [instagram.com/David.devloli](https://www.instagram.com/David.devloli)

--- a/src/FridaHub.App/App.axaml
+++ b/src/FridaHub.App/App.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FridaHub.App.App"
+             RequestedThemeVariant="Default">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/src/FridaHub.App/App.axaml.cs
+++ b/src/FridaHub.App/App.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace FridaHub.App;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/FridaHub.App/FridaHub.App.csproj
+++ b/src/FridaHub.App/FridaHub.App.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.4" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.4" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.4">
+      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
+      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FridaHub.Core\FridaHub.Core.csproj" />
+    <ProjectReference Include="..\FridaHub.Infrastructure\FridaHub.Infrastructure.csproj" />
+    <ProjectReference Include="..\FridaHub.Processes\FridaHub.Processes.csproj" />
+    <ProjectReference Include="..\FridaHub.Codeshare\FridaHub.Codeshare.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FridaHub.App/MainWindow.axaml
+++ b/src/FridaHub.App/MainWindow.axaml
@@ -1,0 +1,9 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="FridaHub.App.MainWindow"
+        Title="FridaHub.App">
+    Welcome to Avalonia!
+</Window>

--- a/src/FridaHub.App/MainWindow.axaml.cs
+++ b/src/FridaHub.App/MainWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace FridaHub.App;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/FridaHub.App/Program.cs
+++ b/src/FridaHub.App/Program.cs
@@ -1,0 +1,21 @@
+﻿using Avalonia;
+using System;
+
+namespace FridaHub.App;
+
+class Program
+{
+    // Initialization code. Don't use any Avalonia, third-party APIs or any
+    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+    // yet and stuff might break.
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}

--- a/src/FridaHub.App/app.manifest
+++ b/src/FridaHub.App/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="FridaHub.App.Desktop"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/src/FridaHub.Codeshare/Class1.cs
+++ b/src/FridaHub.Codeshare/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace FridaHub.Codeshare;
+
+public class Class1
+{
+
+}

--- a/src/FridaHub.Codeshare/FridaHub.Codeshare.csproj
+++ b/src/FridaHub.Codeshare/FridaHub.Codeshare.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FridaHub.Core/Class1.cs
+++ b/src/FridaHub.Core/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace FridaHub.Core;
+
+public class Class1
+{
+
+}

--- a/src/FridaHub.Core/FridaHub.Core.csproj
+++ b/src/FridaHub.Core/FridaHub.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FridaHub.Infrastructure/Class1.cs
+++ b/src/FridaHub.Infrastructure/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace FridaHub.Infrastructure;
+
+public class Class1
+{
+
+}

--- a/src/FridaHub.Infrastructure/FridaHub.Infrastructure.csproj
+++ b/src/FridaHub.Infrastructure/FridaHub.Infrastructure.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/FridaHub.Processes/Class1.cs
+++ b/src/FridaHub.Processes/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace FridaHub.Processes;
+
+public class Class1
+{
+
+}

--- a/src/FridaHub.Processes/FridaHub.Processes.csproj
+++ b/src/FridaHub.Processes/FridaHub.Processes.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Resumo
- Adiciona solução **FridaHub** com projetos App, Core, Infrastructure, Processes e Codeshare
- Configura projetos para .NET 8 com referências e pacotes necessários
- Inclui README com instruções de compilação e informações do autor

## Testes
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_68a7a2177c7c8322922f07bb6ddb7d1a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novos Recursos
  - Primeira versão do app desktop com janela inicial exibindo “Welcome to Avalonia!” e tema Fluent padrão.
  - Inicialização da aplicação configurada para ambiente desktop.

- Documentação
  - README atualizado com novo nome (FridaHub), descrição da solução, estrutura de projetos, instruções de compilação e autoria.

- Chores
  - Adicionada solução e organização dos projetos base.
  - Configurada ignorância de artefatos de build no controle de versão.
  - Preparadas dependências e manifestos necessários para build e execução no Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->