### PR TITLE
Adiciona confirmação de uso autorizado antes da execução

### DIFF
--- a/src/FridaHub.App/ViewModels/RunViewModel.cs
+++ b/src/FridaHub.App/ViewModels/RunViewModel.cs
@@ -1,11 +1,36 @@
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using FridaHub.Core.Interfaces;
 using FridaHub.Core.Models;
 
 namespace FridaHub.App.ViewModels;
 
 public partial class RunViewModel : ObservableObject
 {
+    private readonly ISettingsService _settingsService;
+
+    public RunViewModel(ISettingsService settingsService)
+    {
+        _settingsService = settingsService;
+
+        var result = _settingsService.LoadAsync().GetAwaiter().GetResult();
+        if (result.IsSuccess && result.Value is { } settings)
+        {
+            IsAuthorized = settings.AuthorizedUseAccepted;
+        }
+    }
+
     [ObservableProperty]
     private ObservableCollection<ProcessLine> output = new();
+
+    [ObservableProperty]
+    private bool isAuthorized;
+
+    public async Task SaveAuthorizationAsync()
+    {
+        var settings = _settingsService.Current ?? new Settings();
+        settings.AuthorizedUseAccepted = IsAuthorized;
+        await _settingsService.SaveAsync(settings);
+    }
 }

--- a/src/FridaHub.App/Views/AuthorizationDialog.axaml
+++ b/src/FridaHub.App/Views/AuthorizationDialog.axaml
@@ -1,0 +1,18 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="FridaHub.App.Views.AuthorizationDialog"
+        Title="Uso autorizado"
+        Width="400"
+        Height="200">
+    <StackPanel Margin="16" Spacing="8">
+        <TextBlock TextWrapping="Wrap"
+                   Text="Este software é destinado apenas a uso autorizado. Ao continuar, você concorda em utilizá-lo de forma responsável."/>
+        <CheckBox Content="Li e concordo"
+                  IsChecked="{Binding IsAuthorized}"
+                  Margin="0,8,0,0"/>
+        <Button Content="Continuar"
+                IsEnabled="{Binding IsAuthorized}"
+                HorizontalAlignment="Right"
+                Click="OnContinue"/>
+    </StackPanel>
+</Window>

--- a/src/FridaHub.App/Views/AuthorizationDialog.axaml.cs
+++ b/src/FridaHub.App/Views/AuthorizationDialog.axaml.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using FridaHub.App.ViewModels;
+
+namespace FridaHub.App.Views;
+
+public partial class AuthorizationDialog : Window
+{
+    public AuthorizationDialog()
+    {
+        InitializeComponent();
+    }
+
+    private async void OnContinue(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is RunViewModel vm)
+        {
+            await vm.SaveAuthorizationAsync();
+        }
+        Close();
+    }
+}

--- a/src/FridaHub.App/Views/RunView.axaml
+++ b/src/FridaHub.App/Views/RunView.axaml
@@ -1,7 +1,21 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:FridaHub.App.ViewModels"
+             xmlns:models="clr-namespace:FridaHub.Core.Models;assembly=FridaHub.Core"
              x:Class="FridaHub.App.Views.RunView"
              x:DataType="vm:RunViewModel">
-    <Grid/>
+    <StackPanel Margin="8">
+        <Button Content="Executar"
+                IsEnabled="{Binding IsAuthorized}"
+                Width="100"
+                HorizontalAlignment="Left"
+                Margin="0,0,0,8"/>
+        <ListBox ItemsSource="{Binding Output}">
+            <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="models:ProcessLine">
+                    <TextBlock Text="{Binding Line}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </StackPanel>
 </UserControl>

--- a/src/FridaHub.App/Views/RunView.axaml.cs
+++ b/src/FridaHub.App/Views/RunView.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 using FridaHub.App.ViewModels;
 
 namespace FridaHub.App.Views;
@@ -8,10 +10,24 @@ public partial class RunView : UserControl
     public RunView()
     {
         InitializeComponent();
+        AttachedToVisualTree += OnAttachedToVisualTree;
     }
 
     public RunView(RunViewModel viewModel) : this()
     {
         DataContext = viewModel;
+    }
+
+    private async void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        AttachedToVisualTree -= OnAttachedToVisualTree;
+        if (DataContext is RunViewModel vm && !vm.IsAuthorized)
+        {
+            var dialog = new AuthorizationDialog { DataContext = vm };
+            if (VisualRoot is Window window)
+            {
+                await dialog.ShowDialog(window);
+            }
+        }
     }
 }

--- a/src/FridaHub.Core/Models/Settings.cs
+++ b/src/FridaHub.Core/Models/Settings.cs
@@ -16,4 +16,5 @@ public class Settings
     public string ResourcesFolder { get; set; } = string.Empty;
     public bool ShowElevatedTargets { get; set; }
     public bool EnableJailbreakFeature { get; set; } = false;
+    public bool AuthorizedUseAccepted { get; set; }
 }


### PR DESCRIPTION
## Descrição
- exibe modal com termo de uso autorizado na primeira execução
- persiste aceite nos Settings
- habilita o botão **Executar** somente após concordância
