### PR TITLE
Adicionar seeds de scripts Codeshare e filtro de busca

### DIFF
--- a/src/FridaHub.App/ServiceConfigurator.cs
+++ b/src/FridaHub.App/ServiceConfigurator.cs
@@ -5,6 +5,7 @@ using FridaHub.Processes;
 using FridaHub.Core.Backends;
 using FridaHub.App.ViewModels;
 using FridaHub.App.Views;
+using FridaHub.Codeshare;
 
 namespace FridaHub.App;
 
@@ -15,6 +16,7 @@ public static class ServiceConfigurator
         var services = new ServiceCollection();
 
         services.AddFridaHubInfrastructure();
+        services.AddScoped<CodeshareSeedLoader>();
         services.AddSingleton<ProcessRunner>();
         services.AddSingleton<IAdbBackend, AdbService>();
         services.AddSingleton<IFridaBackend, FridaService>();
@@ -31,6 +33,14 @@ public static class ServiceConfigurator
         services.AddTransient<RunView>();
         services.AddTransient<SettingsView>();
 
-        return services.BuildServiceProvider();
+        var provider = services.BuildServiceProvider();
+
+        using (var scope = provider.CreateScope())
+        {
+            var seeder = scope.ServiceProvider.GetRequiredService<CodeshareSeedLoader>();
+            seeder.LoadAsync().GetAwaiter().GetResult();
+        }
+
+        return provider;
     }
 }

--- a/src/FridaHub.App/ViewModels/ScriptsViewModel.cs
+++ b/src/FridaHub.App/ViewModels/ScriptsViewModel.cs
@@ -1,34 +1,57 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using FridaHub.Core.Models;
+using FridaHub.Core.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace FridaHub.App.ViewModels;
 
 public partial class ScriptsViewModel : ObservableObject
 {
+    private readonly IServiceScopeFactory _scopeFactory;
+    private List<ScriptRef> allScripts = new();
+
     [ObservableProperty]
     private ObservableCollection<ScriptRef> scripts = new();
 
     [ObservableProperty]
     private ScriptRef? selectedScript;
 
-    public ScriptsViewModel()
-    {
-        Scripts.Add(new ScriptRef
-        {
-            Id = Guid.NewGuid(),
-            Title = "Exemplo 1",
-            Author = "Pexe (@David.devloli)",
-            Source = ScriptSource.Internal
-        });
+    [ObservableProperty]
+    private string searchText = string.Empty;
 
-        Scripts.Add(new ScriptRef
+    public ScriptsViewModel(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+        _ = LoadAsync();
+    }
+
+    partial void OnSearchTextChanged(string value) => ApplyFilter();
+
+    private async Task LoadAsync()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IScriptsRepository>();
+        var result = await repo.SearchAsync(string.Empty);
+        if (result.IsSuccess && result.Value != null)
         {
-            Id = Guid.NewGuid(),
-            Title = "Exemplo 2",
-            Author = "Pexe (@David.devloli)",
-            Source = ScriptSource.Codeshare
-        });
+            allScripts = result.Value.ToList();
+            ApplyFilter();
+        }
+    }
+
+    private void ApplyFilter()
+    {
+        var query = SearchText?.Trim() ?? string.Empty;
+        IEnumerable<ScriptRef> filtered = string.IsNullOrWhiteSpace(query)
+            ? allScripts
+            : allScripts.Where(s =>
+                s.Title.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                s.Tags.Any(t => t.Contains(query, StringComparison.OrdinalIgnoreCase)));
+
+        Scripts = new ObservableCollection<ScriptRef>(filtered);
     }
 }

--- a/src/FridaHub.App/Views/ScriptsView.axaml
+++ b/src/FridaHub.App/Views/ScriptsView.axaml
@@ -7,7 +7,8 @@
     <StackPanel Margin="8">
         <TextBox x:Name="SearchBox"
                  Watermark="Buscar scripts..."
-                 Margin="0,0,0,8"/>
+                 Margin="0,0,0,8"
+                 Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"/>
         <ListBox ItemsSource="{Binding Scripts}">
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="models:ScriptRef">

--- a/src/FridaHub.Codeshare/CodeshareSeedLoader.cs
+++ b/src/FridaHub.Codeshare/CodeshareSeedLoader.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using FridaHub.Core.Models;
+using FridaHub.Infrastructure;
+using FridaHub.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FridaHub.Codeshare;
+
+public class CodeshareSeedLoader
+{
+    private readonly FridaHubDbContext _db;
+    private readonly string _seedPath;
+
+    public CodeshareSeedLoader(FridaHubDbContext db)
+    {
+        _db = db;
+        _seedPath = Path.Combine(AppContext.BaseDirectory, "seed.json");
+    }
+
+    public async Task LoadAsync()
+    {
+        if (!File.Exists(_seedPath)) return;
+
+        var json = await File.ReadAllTextAsync(_seedPath);
+        var seeds = JsonSerializer.Deserialize<List<ScriptSeed>>(json);
+        if (seeds is null) return;
+
+        foreach (var seed in seeds)
+        {
+            if (await _db.Scripts.AnyAsync(s => s.Slug == seed.Slug))
+                continue;
+
+            _db.Scripts.Add(new ScriptEntity
+            {
+                Id = Guid.NewGuid(),
+                Source = ScriptSource.Codeshare,
+                Author = seed.Author,
+                Slug = seed.Slug,
+                Title = seed.Title,
+                Tags = seed.Tags,
+                Platforms = seed.Platforms
+            });
+        }
+
+        await _db.SaveChangesAsync();
+    }
+
+    private class ScriptSeed
+    {
+        public string Source { get; set; } = string.Empty;
+        public string Author { get; set; } = string.Empty;
+        public string Slug { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public List<string> Tags { get; set; } = new();
+        public List<string> Platforms { get; set; } = new();
+    }
+}

--- a/src/FridaHub.Codeshare/FridaHub.Codeshare.csproj
+++ b/src/FridaHub.Codeshare/FridaHub.Codeshare.csproj
@@ -6,4 +6,15 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Include="seed.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FridaHub.Core\FridaHub.Core.csproj" />
+    <ProjectReference Include="..\FridaHub.Infrastructure\FridaHub.Infrastructure.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/FridaHub.Codeshare/seed.json
+++ b/src/FridaHub.Codeshare/seed.json
@@ -1,0 +1,82 @@
+[
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "anti-root",
+    "title": "Bypass Root Detection",
+    "tags": ["android", "root", "bypass"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "bypass-ssl",
+    "title": "Bypass SSL Pinning",
+    "tags": ["android", "ssl", "network"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "trace-crypto",
+    "title": "Trace Crypto Operations",
+    "tags": ["android", "crypto"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "hook-http",
+    "title": "Hook HTTP Requests",
+    "tags": ["android", "http"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "dump-strings",
+    "title": "Dump Loaded Strings",
+    "tags": ["android", "strings"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "list-classes",
+    "title": "List Loaded Classes",
+    "tags": ["android", "classes"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "monitor-files",
+    "title": "Monitor File Access",
+    "tags": ["android", "file", "monitor"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "intercept-sms",
+    "title": "Intercept SMS Messages",
+    "tags": ["android", "sms"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "detect-frida",
+    "title": "Detect Frida Presence",
+    "tags": ["android", "frida", "detection"],
+    "platforms": ["Android"]
+  },
+  {
+    "source": "Codeshare",
+    "author": "Pexe (Instagram: David.devloli)",
+    "slug": "hide-debugger",
+    "title": "Hide Debugger",
+    "tags": ["android", "debug"],
+    "platforms": ["Android"]
+  }
+]


### PR DESCRIPTION
## Resumo
- adiciona seed.json com exemplos de scripts do Codeshare
- implementa CodeshareSeedLoader para popular o banco se vazio
- permite buscar e filtrar scripts por texto/tags na tela de Scripts
