### PR TITLE
Corrige build e exposição de scripts

### DIFF
--- a/src/FridaHub.App/ViewModels/DevicesViewModel.cs
+++ b/src/FridaHub.App/ViewModels/DevicesViewModel.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using FridaHub.Core.Backends;
 using FridaHub.Core.Models;
 using FridaHub.Core.Results;
+using System.Threading.Tasks;
 
 namespace FridaHub.App.ViewModels;
 

--- a/src/FridaHub.App/ViewModels/ScriptsViewModel.cs
+++ b/src/FridaHub.App/ViewModels/ScriptsViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using FridaHub.Core.Models;
 using FridaHub.Core.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
 
 namespace FridaHub.App.ViewModels;
 

--- a/src/FridaHub.App/Views/AuthorizationDialog.axaml
+++ b/src/FridaHub.App/Views/AuthorizationDialog.axaml
@@ -1,6 +1,8 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:FridaHub.App.ViewModels"
         x:Class="FridaHub.App.Views.AuthorizationDialog"
+        x:DataType="vm:RunViewModel"
         Title="Uso autorizado"
         Width="400"
         Height="200">

--- a/src/FridaHub.App/Views/RunView.axaml.cs
+++ b/src/FridaHub.App/Views/RunView.axaml.cs
@@ -10,7 +10,7 @@ public partial class RunView : UserControl
     public RunView()
     {
         InitializeComponent();
-        AttachedToVisualTree += OnAttachedToVisualTree;
+        Loaded += OnLoaded;
     }
 
     public RunView(RunViewModel viewModel) : this()
@@ -18,9 +18,9 @@ public partial class RunView : UserControl
         DataContext = viewModel;
     }
 
-    private async void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    private async void OnLoaded(object? sender, RoutedEventArgs e)
     {
-        AttachedToVisualTree -= OnAttachedToVisualTree;
+        Loaded -= OnLoaded;
         if (DataContext is RunViewModel vm && !vm.IsAuthorized)
         {
             var dialog = new AuthorizationDialog { DataContext = vm };

--- a/src/FridaHub.Infrastructure/Entities/ScriptEntity.cs
+++ b/src/FridaHub.Infrastructure/Entities/ScriptEntity.cs
@@ -4,7 +4,7 @@ using FridaHub.Core.Models;
 
 namespace FridaHub.Infrastructure.Entities;
 
-internal class ScriptEntity
+public class ScriptEntity
 {
     public Guid Id { get; set; }
     public ScriptSource Source { get; set; }

--- a/src/FridaHub.Infrastructure/FridaHubDbContext.cs
+++ b/src/FridaHub.Infrastructure/FridaHubDbContext.cs
@@ -9,7 +9,7 @@ public class FridaHubDbContext : DbContext
     {
     }
 
-    internal DbSet<ScriptEntity> Scripts => Set<ScriptEntity>();
+    public DbSet<ScriptEntity> Scripts => Set<ScriptEntity>();
     internal DbSet<FavoriteEntity> Favorites => Set<FavoriteEntity>();
     internal DbSet<RunRecordEntity> Runs => Set<RunRecordEntity>();
     internal DbSet<DeviceEntity> Devices => Set<DeviceEntity>();


### PR DESCRIPTION
## Resumo
- Torna `ScriptEntity` e o conjunto `Scripts` públicos para permitir o carregamento de seeds
- Ajusta view models e views para compilar o app corretamente

## Testes
- `dotnet build`
- `dotnet test`

Autor: Pexe (Instagram: David.devloli)

------
https://chatgpt.com/codex/tasks/task_b_68a7bc6d40588322904ced851db2fc89