### PR TITLE
Definir OutputType como Exe para depuração

### DIFF
--- a/src/FridaHub.App/FridaHub.App.csproj
+++ b/src/FridaHub.App/FridaHub.App.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>


### PR DESCRIPTION
## Descrição
- Ajusta temporariamente o `OutputType` para `Exe` no projeto do aplicativo, permitindo a visualização de logs no console durante a depuração.

