### PR TITLE
feat: adicionar drawer de execução

### DIFF
--- a/src/FridaHub.App/ViewModels/RunViewModel.cs
+++ b/src/FridaHub.App/ViewModels/RunViewModel.cs
@@ -1,6 +1,9 @@
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using FridaHub.Core.Interfaces;
 using FridaHub.Core.Models;
 
@@ -9,6 +12,7 @@ namespace FridaHub.App.ViewModels;
 public partial class RunViewModel : ObservableObject
 {
     private readonly ISettingsService _settingsService;
+    private CancellationTokenSource? _cts;
 
     public RunViewModel(ISettingsService settingsService)
     {
@@ -21,16 +25,99 @@ public partial class RunViewModel : ObservableObject
         }
     }
 
+    public ObservableCollection<DeviceInfo> Devices { get; } = new();
+
+    public IEnumerable<string> Modes { get; } = ["Attach", "Spawn"];
+
+    public IEnumerable<string> Selectors { get; } = ["-U", "-R"];
+
     [ObservableProperty]
     private ObservableCollection<ProcessLine> output = new();
 
     [ObservableProperty]
     private bool isAuthorized;
 
+    [ObservableProperty]
+    private bool isDrawerOpen;
+
+    [ObservableProperty]
+    private DeviceInfo? selectedDevice;
+
+    [ObservableProperty]
+    private string target = string.Empty;
+
+    [ObservableProperty]
+    private string mode = "Attach";
+
+    [ObservableProperty]
+    private string? script;
+
+    [ObservableProperty]
+    private string selector = "-U";
+
+    [ObservableProperty]
+    private string parameters = string.Empty;
+
+    [ObservableProperty]
+    private bool isRunning;
+
     public async Task SaveAuthorizationAsync()
     {
         var settings = _settingsService.Current ?? new Settings();
         settings.AuthorizedUseAccepted = IsAuthorized;
         await _settingsService.SaveAsync(settings);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRun))]
+    private async Task RunAsync()
+    {
+        IsRunning = true;
+        _cts = new CancellationTokenSource();
+        try
+        {
+            await Task.Delay(1000, _cts.Token);
+        }
+        catch (TaskCanceledException)
+        {
+            // ignorado
+        }
+        finally
+        {
+            IsRunning = false;
+        }
+    }
+
+    private bool CanRun() => !IsRunning &&
+                              SelectedDevice is not null &&
+                              !string.IsNullOrWhiteSpace(Target) &&
+                              !string.IsNullOrWhiteSpace(Script);
+
+    [RelayCommand(CanExecute = nameof(IsRunning))]
+    private void Stop()
+    {
+        _cts?.Cancel();
+        IsRunning = false;
+    }
+
+    [RelayCommand]
+    private void OpenDrawer() => IsDrawerOpen = true;
+
+    [RelayCommand]
+    private void CloseDrawer() => IsDrawerOpen = false;
+
+    [RelayCommand]
+    private void SavePreset()
+    {
+        // futuro
+    }
+
+    partial void OnSelectedDeviceChanged(DeviceInfo? value) => RunCommand.NotifyCanExecuteChanged();
+    partial void OnTargetChanged(string value) => RunCommand.NotifyCanExecuteChanged();
+    partial void OnScriptChanged(string? value) => RunCommand.NotifyCanExecuteChanged();
+
+    partial void OnIsRunningChanged(bool value)
+    {
+        RunCommand.NotifyCanExecuteChanged();
+        StopCommand.NotifyCanExecuteChanged();
     }
 }

--- a/src/FridaHub.App/Views/RunView.axaml
+++ b/src/FridaHub.App/Views/RunView.axaml
@@ -4,18 +4,58 @@
              xmlns:models="clr-namespace:FridaHub.Core.Models;assembly=FridaHub.Core"
              x:Class="FridaHub.App.Views.RunView"
              x:DataType="vm:RunViewModel">
-    <StackPanel Margin="8">
-        <Button Content="Executar"
-                IsEnabled="{Binding IsAuthorized}"
-                Width="100"
-                HorizontalAlignment="Left"
-                Margin="0,0,0,8"/>
-        <ListBox ItemsSource="{Binding Output}">
-            <ListBox.ItemTemplate>
-                <DataTemplate x:DataType="models:ProcessLine">
-                    <TextBlock Text="{Binding Line}"/>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
-    </StackPanel>
+    <SplitView IsPaneOpen="{Binding IsDrawerOpen}"
+               PanePlacement="Right"
+               DisplayMode="Overlay">
+        <SplitView.Pane>
+            <Border Width="300">
+                <ScrollViewer>
+                    <StackPanel Margin="8" Spacing="8">
+                        <TextBlock Text="Device"/>
+                        <ComboBox ItemsSource="{Binding Devices}" SelectedItem="{Binding SelectedDevice}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="models:DeviceInfo">
+                                    <TextBlock Text="{Binding Serial}"/>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+
+                        <TextBlock Text="Target"/>
+                        <TextBox Text="{Binding Target}"/>
+
+                        <TextBlock Text="Modo"/>
+                        <ComboBox ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}"/>
+
+                        <TextBlock Text="Script"/>
+                        <TextBox Text="{Binding Script}"/>
+
+                        <TextBlock Text="Selector"/>
+                        <ComboBox ItemsSource="{Binding Selectors}" SelectedItem="{Binding Selector}"/>
+
+                        <TextBlock Text="Parâmetros"/>
+                        <TextBox Text="{Binding Parameters}" Watermark="Parâmetros"/>
+
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button Content="Executar" Command="{Binding RunCommand}"/>
+                            <Button Content="Parar" Command="{Binding StopCommand}"/>
+                            <Button Content="Salvar preset" Command="{Binding SavePresetCommand}" IsEnabled="False"/>
+                            <Button Content="Fechar" Command="{Binding CloseDrawerCommand}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
+        </SplitView.Pane>
+        <SplitView.Content>
+            <StackPanel Margin="8">
+                <Button Content="Abrir painel" Command="{Binding OpenDrawerCommand}" Width="120" HorizontalAlignment="Left" Margin="0,0,0,8"/>
+                <ListBox ItemsSource="{Binding Output}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="models:ProcessLine">
+                            <TextBlock Text="{Binding Line}"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </StackPanel>
+        </SplitView.Content>
+    </SplitView>
 </UserControl>


### PR DESCRIPTION
## Resumo
- implementar drawer lateral de execução com campos obrigatórios e ações
- criar comandos para executar, parar e manipular abertura do painel

## Testes
- `dotnet build`
- `dotnet test`
