### PR TITLE
feat: adicionar histórico de execuções

### DIFF
--- a/src/FridaHub.App/FridaHub.App.csproj
+++ b/src/FridaHub.App/FridaHub.App.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.4" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.4" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Include="Avalonia.Diagnostics" Version="11.3.4">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>

--- a/src/FridaHub.App/ServiceConfigurator.cs
+++ b/src/FridaHub.App/ServiceConfigurator.cs
@@ -25,12 +25,14 @@ public static class ServiceConfigurator
         services.AddSingleton<DevicesViewModel>();
         services.AddSingleton<ScriptsViewModel>();
         services.AddSingleton<RunViewModel>();
+        services.AddSingleton<HistoryViewModel>();
         services.AddSingleton<SettingsViewModel>();
 
         services.AddTransient<MainView>();
         services.AddTransient<DevicesView>();
         services.AddTransient<ScriptsView>();
         services.AddTransient<RunView>();
+        services.AddTransient<HistoryView>();
         services.AddTransient<SettingsView>();
 
         var provider = services.BuildServiceProvider();

--- a/src/FridaHub.App/ViewModels/HistoryViewModel.cs
+++ b/src/FridaHub.App/ViewModels/HistoryViewModel.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FridaHub.Core.Interfaces;
+using FridaHub.Core.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FridaHub.App.ViewModels;
+
+public partial class HistoryViewModel : ObservableObject
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private List<RunRecord> allRecords = new();
+
+    public HistoryViewModel(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+        _ = LoadAsync();
+    }
+
+    [ObservableProperty]
+    private ObservableCollection<RunRecord> records = new();
+
+    [ObservableProperty]
+    private RunRecord? selectedRecord;
+
+    [ObservableProperty]
+    private DateTime? startDate;
+
+    [ObservableProperty]
+    private DateTime? endDate;
+
+    [ObservableProperty]
+    private RunStatus? selectedStatus;
+
+    [ObservableProperty]
+    private string scriptFilter = string.Empty;
+
+    [ObservableProperty]
+    private string deviceFilter = string.Empty;
+
+    public IEnumerable<RunStatus> Statuses { get; } = Enum.GetValues<RunStatus>();
+
+    partial void OnStartDateChanged(DateTime? value) => ApplyFilter();
+    partial void OnEndDateChanged(DateTime? value) => ApplyFilter();
+    partial void OnSelectedStatusChanged(RunStatus? value) => ApplyFilter();
+    partial void OnScriptFilterChanged(string value) => ApplyFilter();
+    partial void OnDeviceFilterChanged(string value) => ApplyFilter();
+
+    private async Task LoadAsync()
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IRunsRepository>();
+        var result = await repo.SearchAsync(string.Empty);
+        if (result.IsSuccess && result.Value is { } list)
+        {
+            allRecords = list.ToList();
+            ApplyFilter();
+        }
+    }
+
+    private void ApplyFilter()
+    {
+        IEnumerable<RunRecord> query = allRecords;
+
+        if (StartDate is { } sd)
+            query = query.Where(r => r.StartedAtUtc?.Date >= sd.Date);
+
+        if (EndDate is { } ed)
+            query = query.Where(r => r.StartedAtUtc?.Date <= ed.Date);
+
+        if (SelectedStatus is { } st)
+            query = query.Where(r => r.Status == st);
+
+        if (!string.IsNullOrWhiteSpace(ScriptFilter))
+            query = query.Where(r => r.ScriptId.ToString().Contains(ScriptFilter, StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrWhiteSpace(DeviceFilter))
+            query = query.Where(r => r.DeviceSerial.Contains(DeviceFilter, StringComparison.OrdinalIgnoreCase));
+
+        Records = new ObservableCollection<RunRecord>(query);
+    }
+
+    [RelayCommand]
+    private void OpenLog(RunRecord record)
+    {
+        if (string.IsNullOrWhiteSpace(record.LogPath) || !File.Exists(record.LogPath))
+            return;
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = record.LogPath,
+                UseShellExecute = true
+            });
+        }
+        catch
+        {
+            // ignorar
+        }
+    }
+}
+

--- a/src/FridaHub.App/ViewModels/MainViewModel.cs
+++ b/src/FridaHub.App/ViewModels/MainViewModel.cs
@@ -11,16 +11,18 @@ public partial class MainViewModel : ObservableObject
     public DevicesViewModel Devices { get; }
     public ScriptsViewModel Scripts { get; }
     public RunViewModel Run { get; }
+    public HistoryViewModel History { get; }
     public SettingsViewModel Settings { get; }
 
     [ObservableProperty]
     private ObservableCollection<string> logs = new();
 
-    public MainViewModel(DevicesViewModel devices, ScriptsViewModel scripts, RunViewModel run, SettingsViewModel settings)
+    public MainViewModel(DevicesViewModel devices, ScriptsViewModel scripts, RunViewModel run, HistoryViewModel history, SettingsViewModel settings)
     {
         Devices = devices;
         Scripts = scripts;
         Run = run;
+        History = history;
         Settings = settings;
 
         AddLog("Aplicação iniciada");

--- a/src/FridaHub.App/ViewModels/RunViewModel.cs
+++ b/src/FridaHub.App/ViewModels/RunViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Mvvm.Input;
 using FridaHub.Core.Interfaces;
 using FridaHub.Core.Models;
 using FridaHub.Infrastructure;
+using FridaHub.Core.Backends;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FridaHub.App.ViewModels;

--- a/src/FridaHub.App/Views/HistoryView.axaml
+++ b/src/FridaHub.App/Views/HistoryView.axaml
@@ -1,0 +1,36 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:FridaHub.App.ViewModels"
+             xmlns:models="clr-namespace:FridaHub.Core.Models;assembly=FridaHub.Core"
+             x:Class="FridaHub.App.Views.HistoryView"
+             x:DataType="vm:HistoryViewModel">
+    <StackPanel Margin="8" Spacing="8">
+        <StackPanel Orientation="Horizontal" Spacing="8">
+            <DatePicker SelectedDate="{Binding StartDate}" Width="140"/>
+            <DatePicker SelectedDate="{Binding EndDate}" Width="140"/>
+            <ComboBox ItemsSource="{Binding Statuses}" SelectedItem="{Binding SelectedStatus}" Width="120"/>
+            <TextBox Text="{Binding ScriptFilter}" Watermark="Script" Width="140"/>
+            <TextBox Text="{Binding DeviceFilter}" Watermark="Device" Width="140"/>
+        </StackPanel>
+        <DataGrid ItemsSource="{Binding Records}"
+                  AutoGenerateColumns="False"
+                  IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Início" Binding="{Binding StartedAtUtc}"/>
+                <DataGridTextColumn Header="Fim" Binding="{Binding EndedAtUtc}"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}"/>
+                <DataGridTextColumn Header="Script" Binding="{Binding ScriptId}"/>
+                <DataGridTextColumn Header="Device" Binding="{Binding DeviceSerial}"/>
+                <DataGridTemplateColumn Header="Ações">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate x:DataType="models:RunRecord">
+                            <Button Content="Abrir log"
+                                    Command="{Binding $parent[UserControl].DataContext.OpenLogCommand}"
+                                    CommandParameter="{Binding}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+    </StackPanel>
+</UserControl>

--- a/src/FridaHub.App/Views/HistoryView.axaml.cs
+++ b/src/FridaHub.App/Views/HistoryView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using FridaHub.App.ViewModels;
+
+namespace FridaHub.App.Views;
+
+public partial class HistoryView : UserControl
+{
+    public HistoryView()
+    {
+        InitializeComponent();
+    }
+
+    public HistoryView(HistoryViewModel viewModel) : this()
+    {
+        DataContext = viewModel;
+    }
+}

--- a/src/FridaHub.App/Views/MainView.axaml
+++ b/src/FridaHub.App/Views/MainView.axaml
@@ -24,7 +24,7 @@
                 <views:ScriptsView DataContext="{Binding Scripts}"/>
             </TabItem>
             <TabItem Header="Histórico">
-                <views:ScriptsView DataContext="{Binding Scripts}"/>
+                <views:HistoryView DataContext="{Binding History}"/>
             </TabItem>
             <TabItem Header="Configurações">
                 <views:SettingsView DataContext="{Binding Settings}"/>


### PR DESCRIPTION
## Resumo
- criar tab Histórico com filtros por data, status, script e device
- permitir abrir o log JSONL no editor padrão do sistema

## Testes
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_b_68a7cb4146a083229191c9f7bcc22965