### PR TITLE
feat: adicionar configurações e placeholder de jailbreak

### DIFF
--- a/src/FridaHub.App/ViewModels/SettingsViewModel.cs
+++ b/src/FridaHub.App/ViewModels/SettingsViewModel.cs
@@ -1,9 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FridaHub.Core.Interfaces;
+using FridaHub.Core.Models;
+using FridaHub.Processes;
 
 namespace FridaHub.App.ViewModels;
 
 public partial class SettingsViewModel : ObservableObject
 {
+    private readonly ISettingsService _settingsService;
+    private readonly ProcessRunner _runner;
+
+    public SettingsViewModel(ISettingsService settingsService, ProcessRunner runner)
+    {
+        _settingsService = settingsService;
+        _runner = runner;
+        LoadAsync().GetAwaiter().GetResult();
+    }
+
+    public Theme[] Themes { get; } = Enum.GetValues<Theme>();
+
     [ObservableProperty]
     private string? adbPath;
+
+    [ObservableProperty]
+    private string? fridaPath;
+
+    [ObservableProperty]
+    private string logsFolder = string.Empty;
+
+    [ObservableProperty]
+    private string resourcesFolder = string.Empty;
+
+    [ObservableProperty]
+    private Theme theme;
+
+    [ObservableProperty]
+    private bool showElevatedTargets;
+
+    [ObservableProperty]
+    private string toolsTestResult = string.Empty;
+
+    private async Task LoadAsync()
+    {
+        var result = await _settingsService.LoadAsync();
+        if (result.IsSuccess && result.Value is not null)
+        {   // TODO(Jailbreak): implementar suporte futuro de forma segura e autorizada.
+            var s = result.Value;
+            s.EnableJailbreakFeature = false;
+            AdbPath = s.AdbPath;
+            FridaPath = s.FridaPath;
+            LogsFolder = s.LogsFolder;
+            ResourcesFolder = s.ResourcesFolder;
+            Theme = s.Theme;
+            ShowElevatedTargets = s.ShowElevatedTargets;
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        var settings = new Settings
+        {
+            AdbPath = AdbPath,
+            FridaPath = FridaPath,
+            LogsFolder = LogsFolder,
+            ResourcesFolder = ResourcesFolder,
+            Theme = Theme,
+            ShowElevatedTargets = ShowElevatedTargets,
+            EnableJailbreakFeature = false,
+            AuthorizedUseAccepted = _settingsService.Current?.AuthorizedUseAccepted ?? false
+        };
+        await _settingsService.SaveAsync(settings);
+    }
+
+    [RelayCommand]
+    private async Task TestToolsAsync()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(await RunVersion(AdbPath, "version"));
+        sb.AppendLine(await RunVersion(FridaPath, "--version"));
+        ToolsTestResult = sb.ToString().Trim();
+    }
+
+    private async Task<string> RunVersion(string? path, string args)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return "Caminho não configurado";
+
+        try
+        {
+            var run = _runner.Run(path, args);
+            var output = new List<string>();
+            await foreach (var line in run.Output)
+                output.Add(line.Line);
+            var exit = await run.WaitForExitAsync();
+            return exit == 0
+                ? string.Join('\n', output)
+                : $"Erro ({exit})";
+        }
+        catch (Exception ex)
+        {
+            return $"Erro: {ex.Message}";
+        }
+    }
 }

--- a/src/FridaHub.App/Views/DevicesView.axaml
+++ b/src/FridaHub.App/Views/DevicesView.axaml
@@ -18,6 +18,19 @@
                             <Border Background="LightGray" Padding="4" CornerRadius="4" Margin="8,0,0,0" IsVisible="{Binding IsEmulator}">
                                 <TextBlock Text="Emulador" FontSize="10"/>
                             </Border>
+                            <Border Background="LightGray" Padding="4" CornerRadius="4" Margin="8,0,0,0" IsVisible="False">
+                                <!-- TODO(Jailbreak): implementar suporte futuro de forma segura e autorizada -->
+                                <Border.Styles>
+                                    <Style Selector="Border">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Platform}" Value="IOS">
+                                                <Setter Property="IsVisible" Value="True"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Styles>
+                                <TextBlock Text="Jailbreak (futuro)" FontSize="10"/>
+                            </Border>
                         </StackPanel>
                     </Border>
                 </DataTemplate>

--- a/src/FridaHub.App/Views/SettingsView.axaml
+++ b/src/FridaHub.App/Views/SettingsView.axaml
@@ -3,7 +3,49 @@
              xmlns:vm="clr-namespace:FridaHub.App.ViewModels"
              x:Class="FridaHub.App.Views.SettingsView"
              x:DataType="vm:SettingsViewModel">
-    <Grid>
-        <TextBlock Text="Configurações" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-    </Grid>
+    <ScrollViewer>
+        <StackPanel Margin="8" Spacing="8">
+            <TextBlock Text="Configurações" FontWeight="Bold" FontSize="16"/> 
+
+            <StackPanel>
+                <TextBlock Text="Caminho do adb"/>
+                <TextBox Text="{Binding AdbPath}"/>
+            </StackPanel>
+
+            <StackPanel>
+                <TextBlock Text="Caminho do frida"/>
+                <TextBox Text="{Binding FridaPath}"/>
+            </StackPanel>
+
+            <StackPanel>
+                <TextBlock Text="Pasta de recursos"/>
+                <TextBox Text="{Binding ResourcesFolder}"/>
+            </StackPanel>
+
+            <StackPanel>
+                <TextBlock Text="Pasta de logs"/>
+                <TextBox Text="{Binding LogsFolder}"/>
+            </StackPanel>
+
+            <StackPanel>
+                <TextBlock Text="Tema"/>
+                <ComboBox ItemsSource="{Binding Themes}" SelectedItem="{Binding Theme}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
+
+            <ToggleSwitch IsChecked="{Binding ShowElevatedTargets}" Content="Mostrar alvos elevados"/>
+
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Content="Salvar" Command="{Binding SaveCommand}"/>
+                <Button Content="Testar ferramentas" Command="{Binding TestToolsCommand}"/>
+            </StackPanel>
+
+            <TextBlock Text="{Binding ToolsTestResult}" TextWrapping="Wrap" Foreground="Gray"/>
+        </StackPanel>
+    </ScrollViewer>
 </UserControl>

--- a/src/FridaHub.Processes/FridaService.cs
+++ b/src/FridaHub.Processes/FridaService.cs
@@ -16,6 +16,8 @@ public class FridaService : IFridaBackend
         _runner = runner;
     }
 
+    // TODO(Jailbreak): implementar suporte futuro de forma segura e autorizada.
+
     public IAsyncEnumerable<ProcessLine> RunCodeshareAsync(string author, string slug, string package, string? selector = null, CancellationToken cancellationToken = default)
     {
         var args = $"--codeshare {author}/{slug} -f {package} --no-pause";


### PR DESCRIPTION
## Resumo
- implementar tela de configurações com caminhos, pastas, tema e teste de ferramentas
- exibir selo cinza "Jailbreak (futuro)" para dispositivos iOS
- incluir comentários TODO sobre suporte futuro de jailbreak
