### PR TITLE
Adicionar painel de diagnósticos e melhorias de usabilidade

### DIFF
--- a/src/FridaHub.App/ServiceConfigurator.cs
+++ b/src/FridaHub.App/ServiceConfigurator.cs
@@ -29,6 +29,7 @@ public static class ServiceConfigurator
         services.AddSingleton<RunViewModel>();
         services.AddSingleton<HistoryViewModel>();
         services.AddSingleton<SettingsViewModel>();
+        services.AddSingleton<DiagnosticsViewModel>();
 
         services.AddTransient<MainView>();
         services.AddTransient<DevicesView>();
@@ -36,6 +37,7 @@ public static class ServiceConfigurator
         services.AddTransient<RunView>();
         services.AddTransient<HistoryView>();
         services.AddTransient<SettingsView>();
+        services.AddTransient<DiagnosticsView>();
 
         var provider = services.BuildServiceProvider();
 

--- a/src/FridaHub.App/ViewModels/DiagnosticsViewModel.cs
+++ b/src/FridaHub.App/ViewModels/DiagnosticsViewModel.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FridaHub.Core.Interfaces;
+using FridaHub.Core.Models;
+
+namespace FridaHub.App.ViewModels;
+
+public partial class DiagnosticsViewModel : ObservableObject
+{
+    private readonly IDiagnosticsService _diagnostics;
+
+    public DiagnosticsViewModel(IDiagnosticsService diagnostics)
+    {
+        _diagnostics = diagnostics;
+    }
+
+    public string? LastError => _diagnostics.LastError;
+    public ObservableCollection<string> LastCommands => _diagnostics.LastCommands;
+    public TimeSpan? LastAttachTime => _diagnostics.LastAttachTime;
+    public TimeSpan? LastSpawnTime => _diagnostics.LastSpawnTime;
+    public ObservableCollection<DeviceInfo> LastDevices => _diagnostics.LastDevices;
+
+    [RelayCommand]
+    private void ExportReport()
+    {
+        var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".fridahub");
+        _diagnostics.ExportReport(dir, true);
+    }
+}

--- a/src/FridaHub.App/ViewModels/MainViewModel.cs
+++ b/src/FridaHub.App/ViewModels/MainViewModel.cs
@@ -13,17 +13,19 @@ public partial class MainViewModel : ObservableObject
     public RunViewModel Run { get; }
     public HistoryViewModel History { get; }
     public SettingsViewModel Settings { get; }
+    public DiagnosticsViewModel Diagnostics { get; }
 
     [ObservableProperty]
     private ObservableCollection<string> logs = new();
 
-    public MainViewModel(DevicesViewModel devices, ScriptsViewModel scripts, RunViewModel run, HistoryViewModel history, SettingsViewModel settings)
+    public MainViewModel(DevicesViewModel devices, ScriptsViewModel scripts, RunViewModel run, HistoryViewModel history, SettingsViewModel settings, DiagnosticsViewModel diagnostics)
     {
         Devices = devices;
         Scripts = scripts;
         Run = run;
         History = history;
         Settings = settings;
+        Diagnostics = diagnostics;
 
         AddLog("Aplicação iniciada");
     }
@@ -39,6 +41,14 @@ public partial class MainViewModel : ObservableObject
     [RelayCommand]
     private void RefreshDevices()
     {
+        Devices.RefreshCommand.Execute(null);
         AddLog("Dispositivos atualizados");
+    }
+
+    [RelayCommand]
+    private void ClearConsole()
+    {
+        Logs.Clear();
+        OnPropertyChanged(nameof(ConsoleText));
     }
 }

--- a/src/FridaHub.App/Views/DevicesView.axaml
+++ b/src/FridaHub.App/Views/DevicesView.axaml
@@ -10,27 +10,40 @@
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="models:DeviceInfo">
                     <Border Margin="0,0,0,8" Padding="8" BorderThickness="1" BorderBrush="Gray" CornerRadius="4">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <StackPanel>
-                                <TextBlock Text="{Binding Model}" FontWeight="Bold"/>
-                                <TextBlock Text="{Binding Serial}" FontSize="10" Foreground="Gray"/>
+                        <StackPanel Spacing="8">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Model}" FontWeight="Bold"/>
+                                    <TextBlock Text="{Binding Serial}" FontSize="10" Foreground="Gray"/>
+                                </StackPanel>
+                                <Border Background="LightGray" Padding="4" CornerRadius="4" Margin="8,0,0,0" IsVisible="{Binding IsEmulator}">
+                                    <TextBlock Text="Emulador" FontSize="10"/>
+                                </Border>
+                                <Border Background="LightGray" Padding="4" CornerRadius="4" Margin="8,0,0,0" IsVisible="False">
+                                    <!-- TODO(Jailbreak): implementar suporte futuro de forma segura e autorizada -->
+                                    <Border.Styles>
+                                        <Style Selector="Border">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Platform}" Value="IOS">
+                                                    <Setter Property="IsVisible" Value="True"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Styles>
+                                    <TextBlock Text="Jailbreak (futuro)" FontSize="10"/>
+                                </Border>
                             </StackPanel>
-                            <Border Background="LightGray" Padding="4" CornerRadius="4" Margin="8,0,0,0" IsVisible="{Binding IsEmulator}">
-                                <TextBlock Text="Emulador" FontSize="10"/>
-                            </Border>
-                            <Border Background="LightGray" Padding="4" CornerRadius="4" Margin="8,0,0,0" IsVisible="False">
-                                <!-- TODO(Jailbreak): implementar suporte futuro de forma segura e autorizada -->
-                                <Border.Styles>
-                                    <Style Selector="Border">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding Platform}" Value="IOS">
-                                                <Setter Property="IsVisible" Value="True"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Border.Styles>
-                                <TextBlock Text="Jailbreak (futuro)" FontSize="10"/>
-                            </Border>
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <Button Content="Listar processos"
+                                        Command="{Binding $parent[UserControl].DataContext.ListProcessesCommand}"
+                                        CommandParameter="{Binding}"/>
+                                <Button Content="Forward portas"
+                                        Command="{Binding $parent[UserControl].DataContext.ForwardPortsCommand}"
+                                        CommandParameter="{Binding}"/>
+                                <Button Content="Re-testar ferramentas"
+                                        Command="{Binding $parent[UserControl].DataContext.RetestToolsCommand}"
+                                        CommandParameter="{Binding}"/>
+                            </StackPanel>
                         </StackPanel>
                     </Border>
                 </DataTemplate>

--- a/src/FridaHub.App/Views/DiagnosticsView.axaml
+++ b/src/FridaHub.App/Views/DiagnosticsView.axaml
@@ -1,0 +1,28 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:FridaHub.App.ViewModels"
+             xmlns:models="clr-namespace:FridaHub.Core.Models;assembly=FridaHub.Core"
+             x:Class="FridaHub.App.Views.DiagnosticsView"
+             x:DataType="vm:DiagnosticsViewModel">
+    <ScrollViewer>
+        <StackPanel Margin="8" Spacing="8">
+            <TextBlock Text="Último erro:" FontWeight="Bold"/>
+            <TextBlock Text="{Binding LastError}"/>
+            <TextBlock Text="Últimos comandos:" FontWeight="Bold" Margin="0,8,0,0"/>
+            <ListBox ItemsSource="{Binding LastCommands}"/>
+            <TextBlock Text="Tempo de attach:" FontWeight="Bold" Margin="0,8,0,0"/>
+            <TextBlock Text="{Binding LastAttachTime}"/>
+            <TextBlock Text="Tempo de spawn:" FontWeight="Bold" Margin="0,8,0,0"/>
+            <TextBlock Text="{Binding LastSpawnTime}"/>
+            <TextBlock Text="Últimos devices:" FontWeight="Bold" Margin="0,8,0,0"/>
+            <ListBox ItemsSource="{Binding LastDevices}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="models:DeviceInfo">
+                        <TextBlock Text="{Binding Serial}"/>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+            <Button Content="Exportar relatório" Command="{Binding ExportReportCommand}" Margin="0,8,0,0"/>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/FridaHub.App/Views/DiagnosticsView.axaml.cs
+++ b/src/FridaHub.App/Views/DiagnosticsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace FridaHub.App.Views;
+
+public partial class DiagnosticsView : UserControl
+{
+    public DiagnosticsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/FridaHub.App/Views/MainView.axaml
+++ b/src/FridaHub.App/Views/MainView.axaml
@@ -29,6 +29,9 @@
             <TabItem Header="Configurações">
                 <views:SettingsView DataContext="{Binding Settings}"/>
             </TabItem>
+            <TabItem Header="Diagnósticos">
+                <views:DiagnosticsView DataContext="{Binding Diagnostics}"/>
+            </TabItem>
         </TabControl>
     </DockPanel>
 </Window>

--- a/src/FridaHub.App/Views/MainView.axaml.cs
+++ b/src/FridaHub.App/Views/MainView.axaml.cs
@@ -25,6 +25,13 @@ public partial class MainView : Window
             return;
         }
 
+        if (e.KeyModifiers == KeyModifiers.Control && e.Key == Key.L && DataContext is MainViewModel vm2)
+        {
+            vm2.ClearConsoleCommand.Execute(null);
+            e.Handled = true;
+            return;
+        }
+
         if (e.KeyModifiers == KeyModifiers.None && e.Key == Key.Oem2)
         {
             var tabs = this.FindControl<TabControl>("MainTabs");

--- a/src/FridaHub.App/Views/RunView.axaml
+++ b/src/FridaHub.App/Views/RunView.axaml
@@ -5,6 +5,9 @@
              xmlns:conv="clr-namespace:FridaHub.App.Converters"
              x:Class="FridaHub.App.Views.RunView"
              x:DataType="vm:RunViewModel">
+    <UserControl.InputBindings>
+        <KeyBinding Gesture="Ctrl+L" Command="{Binding ClearOutputCommand}"/>
+    </UserControl.InputBindings>
     <UserControl.Resources>
         <conv:OriginConverter x:Key="OriginConverter"/>
     </UserControl.Resources>

--- a/src/FridaHub.Core/Interfaces/IDiagnosticsService.cs
+++ b/src/FridaHub.Core/Interfaces/IDiagnosticsService.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using FridaHub.Core.Models;
+
+namespace FridaHub.Core.Interfaces;
+
+public interface IDiagnosticsService
+{
+    string? LastError { get; }
+    ObservableCollection<string> LastCommands { get; }
+    TimeSpan? LastAttachTime { get; }
+    TimeSpan? LastSpawnTime { get; }
+    ObservableCollection<DeviceInfo> LastDevices { get; }
+
+    void RecordError(string message);
+    void RecordCommand(string command);
+    void RecordAttachTime(TimeSpan duration);
+    void RecordSpawnTime(TimeSpan duration);
+    void RecordDevices(IEnumerable<DeviceInfo> devices);
+    string ExportReport(string directory, bool markdown);
+}

--- a/src/FridaHub.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/FridaHub.Infrastructure/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IRunsRepository, EfRunsRepository>();
         services.AddScoped<IDevicesRepository, EfDevicesRepository>();
         services.AddSingleton<ISettingsService, JsonSettingsService>();
+        services.AddSingleton<IDiagnosticsService, DiagnosticsService>();
 
         return services;
     }

--- a/src/FridaHub.Infrastructure/Services/DiagnosticsService.cs
+++ b/src/FridaHub.Infrastructure/Services/DiagnosticsService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using FridaHub.Core.Interfaces;
+using FridaHub.Core.Models;
+
+namespace FridaHub.Infrastructure.Services;
+
+public class DiagnosticsService : IDiagnosticsService
+{
+    public string? LastError { get; private set; }
+    public ObservableCollection<string> LastCommands { get; } = new();
+    public TimeSpan? LastAttachTime { get; private set; }
+    public TimeSpan? LastSpawnTime { get; private set; }
+    public ObservableCollection<DeviceInfo> LastDevices { get; } = new();
+
+    public void RecordError(string message) => LastError = message;
+    public void RecordCommand(string command) => LastCommands.Add(command);
+    public void RecordAttachTime(TimeSpan duration) => LastAttachTime = duration;
+    public void RecordSpawnTime(TimeSpan duration) => LastSpawnTime = duration;
+    public void RecordDevices(IEnumerable<DeviceInfo> devices)
+    {
+        LastDevices.Clear();
+        foreach (var d in devices)
+            LastDevices.Add(d);
+    }
+
+    public string ExportReport(string directory, bool markdown)
+    {
+        Directory.CreateDirectory(directory);
+        var ext = markdown ? "md" : "txt";
+        var file = Path.Combine(directory, $"diagnostico-{DateTime.UtcNow:yyyyMMddHHmmss}.{ext}");
+        var sb = new StringBuilder();
+        if (markdown)
+        {
+            sb.AppendLine("# Relatório de Diagnóstico");
+            sb.AppendLine();
+            sb.AppendLine("## Último erro");
+            sb.AppendLine(LastError ?? "Nenhum");
+            sb.AppendLine();
+            sb.AppendLine("## Últimos comandos");
+            foreach (var c in LastCommands)
+                sb.AppendLine($"- {c}");
+            sb.AppendLine();
+            sb.AppendLine("## Tempo de attach");
+            sb.AppendLine(LastAttachTime?.ToString() ?? "N/A");
+            sb.AppendLine();
+            sb.AppendLine("## Tempo de spawn");
+            sb.AppendLine(LastSpawnTime?.ToString() ?? "N/A");
+            sb.AppendLine();
+            sb.AppendLine("## Últimos devices");
+            foreach (var d in LastDevices)
+                sb.AppendLine($"- {d.Serial}");
+        }
+        else
+        {
+            sb.AppendLine("Relatório de Diagnóstico");
+            sb.AppendLine($"Último erro: {LastError ?? "Nenhum"}");
+            sb.AppendLine("Últimos comandos:");
+            foreach (var c in LastCommands)
+                sb.AppendLine(c);
+            sb.AppendLine($"Tempo de attach: {LastAttachTime?.ToString() ?? "N/A"}");
+            sb.AppendLine($"Tempo de spawn: {LastSpawnTime?.ToString() ?? "N/A"}");
+            sb.AppendLine("Últimos devices:");
+            foreach (var d in LastDevices)
+                sb.AppendLine(d.Serial);
+        }
+        File.WriteAllText(file, sb.ToString());
+        return file;
+    }
+}


### PR DESCRIPTION
## Resumo
- Criado serviço e painel de diagnósticos com exportação de relatório em arquivo
- Adicionados atalhos de teclado para busca, recarregar dispositivos e limpar console
- Inclusos botões rápidos nos cards de dispositivos para processos, forward e re-teste

## Testes
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_68a7df4273308322b727154eebc5e7c7