### PR TITLE
Corrige abertura de diálogos em ScriptsView

### DIFF
--- a/src/FridaHub.App/Views/ScriptsView.axaml.cs
+++ b/src/FridaHub.App/Views/ScriptsView.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using FridaHub.App.ViewModels;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using Avalonia.VisualTree;
@@ -23,6 +24,9 @@ public partial class ScriptsView : UserControl
     {
         if (DataContext is not ScriptsViewModel vm) return;
 
+        var window = this.GetVisualRoot() as Window;
+        if (window is null) return;
+
         var ofd = new OpenFileDialog
         {
             AllowMultiple = false,
@@ -32,18 +36,18 @@ public partial class ScriptsView : UserControl
             }
         };
 
-        var paths = await ofd.ShowAsync((Window)this.GetVisualRoot());
+        var paths = await ofd.ShowAsync(window);
         var path = paths?.FirstOrDefault();
         if (string.IsNullOrEmpty(path)) return;
 
         var titleDialog = new TextInputDialog();
         titleDialog.SetPrompt("Título do script");
-        var title = await titleDialog.ShowDialog<string?>(this);
+        var title = await titleDialog.ShowDialog<string?>(window);
         if (string.IsNullOrWhiteSpace(title)) return;
 
         var tagsDialog = new TextInputDialog();
         tagsDialog.SetPrompt("Tags (separadas por vírgula)");
-        var tagsText = await tagsDialog.ShowDialog<string?>(this);
+        var tagsText = await tagsDialog.ShowDialog<string?>(window);
         var tags = tagsText?.Split(',', StringSplitOptions.RemoveEmptyEntries)
             .Select(t => t.Trim()).Where(t => t.Length > 0).ToList() ?? new List<string>();
 


### PR DESCRIPTION
## Resumo
- garante acesso à janela raiz antes de abrir diálogos
- adiciona importação de System para usar StringSplitOptions
