### PR TITLE
Instalação automática do frida-server nos dispositivos Android

### DIFF
--- a/src/FridaHub.App/Converters/FridaStatusEnabledConverter.cs
+++ b/src/FridaHub.App/Converters/FridaStatusEnabledConverter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using FridaHub.Core.Models;
+
+namespace FridaHub.App.Converters;
+
+public class FridaStatusEnabledConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is FridaStatus status && status != FridaStatus.Installing && status != FridaStatus.Ready;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/FridaHub.App/Converters/FridaStatusTextConverter.cs
+++ b/src/FridaHub.App/Converters/FridaStatusTextConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using FridaHub.Core.Models;
+
+namespace FridaHub.App.Converters;
+
+public class FridaStatusTextConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is FridaStatus status ? status switch
+        {
+            FridaStatus.Ready => "Pronto (frida-server ativo)",
+            FridaStatus.Error => "Erro",
+            FridaStatus.Installing => "Instalando...",
+            _ => "Instalar frida-server"
+        } : "Instalar frida-server";
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/FridaHub.App/Converters/FridaStatusToColorConverter.cs
+++ b/src/FridaHub.App/Converters/FridaStatusToColorConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using FridaHub.Core.Models;
+
+namespace FridaHub.App.Converters;
+
+public class FridaStatusToColorConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is FridaStatus status ? status switch
+        {
+            FridaStatus.Ready => Brushes.LightGreen,
+            FridaStatus.Error => Brushes.LightCoral,
+            FridaStatus.Installing => Brushes.LightGoldenrodYellow,
+            _ => Brushes.Orange
+        } : Brushes.Orange;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/src/FridaHub.App/ServiceConfigurator.cs
+++ b/src/FridaHub.App/ServiceConfigurator.cs
@@ -22,6 +22,7 @@ public static class ServiceConfigurator
         services.AddSingleton<IAdbBackend, AdbService>();
         services.AddSingleton<IFridaBackend, FridaService>();
         services.AddSingleton<IFridaVersionChecker, FridaVersionChecker>();
+        services.AddSingleton<IFridaInstaller, FridaInstaller>();
 
         services.AddSingleton<MainViewModel>();
         services.AddSingleton<DevicesViewModel>();

--- a/src/FridaHub.App/ViewModels/DevicesViewModel.cs
+++ b/src/FridaHub.App/ViewModels/DevicesViewModel.cs
@@ -16,6 +16,7 @@ public partial class DevicesViewModel : ObservableObject
     private readonly IAdbBackend _adb;
     private readonly IFridaBackend _frida;
     private readonly IDiagnosticsService _diagnostics;
+    private readonly IFridaInstaller _installer;
 
     [ObservableProperty]
     private ObservableCollection<DeviceInfo> devices = new();
@@ -23,11 +24,12 @@ public partial class DevicesViewModel : ObservableObject
     [ObservableProperty]
     private DeviceInfo? selectedDevice;
 
-    public DevicesViewModel(IAdbBackend adb, IFridaBackend frida, IDiagnosticsService diagnostics)
+    public DevicesViewModel(IAdbBackend adb, IFridaBackend frida, IDiagnosticsService diagnostics, IFridaInstaller installer)
     {
         _adb = adb;
         _frida = frida;
         _diagnostics = diagnostics;
+        _installer = installer;
     }
 
     [RelayCommand]
@@ -95,5 +97,13 @@ public partial class DevicesViewModel : ObservableObject
     {
         _diagnostics.RecordCommand($"retest {device.Serial}");
         RefreshCommand.Execute(null);
+    }
+
+    [RelayCommand]
+    private async Task InstallFrida(DeviceInfo device)
+    {
+        device.Status = FridaStatus.Installing;
+        var result = await _installer.InstallAsync(device.Serial);
+        device.Status = result.IsSuccess ? FridaStatus.Ready : FridaStatus.Error;
     }
 }

--- a/src/FridaHub.App/Views/DevicesView.axaml
+++ b/src/FridaHub.App/Views/DevicesView.axaml
@@ -7,6 +7,9 @@
              x:DataType="vm:DevicesViewModel">
     <UserControl.Resources>
         <conv:IosVisibilityConverter x:Key="IosVisibilityConverter"/>
+        <conv:FridaStatusToColorConverter x:Key="FridaStatusColorConverter"/>
+        <conv:FridaStatusTextConverter x:Key="FridaStatusTextConverter"/>
+        <conv:FridaStatusEnabledConverter x:Key="FridaStatusEnabledConverter"/>
     </UserControl.Resources>
     <StackPanel Margin="8">
         <Button Content="Atualizar" Command="{Binding RefreshCommand}" Margin="0,0,0,8"/>
@@ -33,6 +36,11 @@
                                 </Border>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="4">
+                                <Button Content="{Binding Status, Converter={StaticResource FridaStatusTextConverter}}"
+                                        Background="{Binding Status, Converter={StaticResource FridaStatusColorConverter}}"
+                                        IsEnabled="{Binding Status, Converter={StaticResource FridaStatusEnabledConverter}}"
+                                        Command="{Binding $parent[UserControl].DataContext.InstallFridaCommand}"
+                                        CommandParameter="{Binding}"/>
                                 <Button Content="Listar processos"
                                         Command="{Binding $parent[UserControl].DataContext.ListProcessesCommand}"
                                         CommandParameter="{Binding}"/>

--- a/src/FridaHub.Core/Backends/IAdbBackend.cs
+++ b/src/FridaHub.Core/Backends/IAdbBackend.cs
@@ -8,5 +8,6 @@ public interface IAdbBackend
     Task<Result> StartServerAsync();
     Task<Result<IEnumerable<DeviceInfo>>> ListDevicesAsync();
     Task<Result<Dictionary<string, string>>> GetPropsAsync(string serial);
+    Task<Result<string>> GetPropAsync(string serial, string key);
     Task<Result> ForwardPortsAsync(string serial, int localPort, int remotePort);
 }

--- a/src/FridaHub.Core/Interfaces/IFridaInstaller.cs
+++ b/src/FridaHub.Core/Interfaces/IFridaInstaller.cs
@@ -1,0 +1,8 @@
+using FridaHub.Core.Results;
+
+namespace FridaHub.Core.Interfaces;
+
+public interface IFridaInstaller
+{
+    Task<Result> InstallAsync(string serial);
+}

--- a/src/FridaHub.Core/Models/DeviceInfo.cs
+++ b/src/FridaHub.Core/Models/DeviceInfo.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace FridaHub.Core.Models;
 
 public enum DevicePlatform
@@ -7,7 +9,15 @@ public enum DevicePlatform
     Unknown
 }
 
-public class DeviceInfo
+public enum FridaStatus
+{
+    NotInstalled,
+    Installing,
+    Ready,
+    Error
+}
+
+public class DeviceInfo : INotifyPropertyChanged
 {
     public string Serial { get; set; } = string.Empty;
     public string Model { get; set; } = string.Empty;
@@ -15,4 +25,20 @@ public class DeviceInfo
     public DevicePlatform Platform { get; set; }
     public Dictionary<string, string> Props { get; set; } = new();
     public DateTime LastSeenUtc { get; set; }
+
+    private FridaStatus status = FridaStatus.NotInstalled;
+    public FridaStatus Status
+    {
+        get => status;
+        set
+        {
+            if (status != value)
+            {
+                status = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Status)));
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 }

--- a/src/FridaHub.Processes/AssemblyInfo.cs
+++ b/src/FridaHub.Processes/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("FridaHub.Processes.Tests")]

--- a/src/FridaHub.Processes/FridaHub.Processes.csproj
+++ b/src/FridaHub.Processes/FridaHub.Processes.csproj
@@ -8,4 +8,8 @@
   <ItemGroup>
     <ProjectReference Include="..\FridaHub.Core\FridaHub.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SharpCompress" Version="0.36.0" />
+  </ItemGroup>
 </Project>

--- a/src/FridaHub.Processes/FridaInstaller.cs
+++ b/src/FridaHub.Processes/FridaInstaller.cs
@@ -1,0 +1,108 @@
+using FridaHub.Core.Backends;
+using FridaHub.Core.Interfaces;
+using FridaHub.Core.Results;
+using SharpCompress.Compressors.Xz;
+using System.Net.Http;
+
+namespace FridaHub.Processes;
+
+public class FridaInstaller : IFridaInstaller
+{
+    private readonly IAdbBackend _adb;
+    private readonly ProcessRunner _runner;
+    private readonly HttpClient _http;
+    private const string Version = "16.7.7";
+
+    public FridaInstaller(IAdbBackend adb, ProcessRunner runner, HttpClient? httpClient = null)
+    {
+        _adb = adb;
+        _runner = runner;
+        _http = httpClient ?? new HttpClient();
+    }
+
+    public async Task<Result> InstallAsync(string serial)
+    {
+        try
+        {
+            var binResult = await GetServerBinaryNameAsync(serial);
+            if (!binResult.IsSuccess || string.IsNullOrWhiteSpace(binResult.Value))
+                return Result.Failure("ABI não suportada");
+            var binaryName = binResult.Value!;
+            var localPathResult = await EnsureBinaryAsync(binaryName);
+            if (!localPathResult.IsSuccess)
+                return Result.Failure(localPathResult.Error!.Message);
+            var localPath = localPathResult.Value!;
+
+            await RunAdbAsync($"-s {serial} push \"{localPath}\" /data/local/tmp/frida-server");
+            await RunAdbAsync($"-s {serial} shell chmod +x /data/local/tmp/frida-server");
+            await RunAdbAsync($"-s {serial} shell \"nohup /data/local/tmp/frida-server >/dev/null 2>&1 &\"");
+            await _adb.ForwardPortsAsync(serial, 27042, 27042);
+            await _adb.ForwardPortsAsync(serial, 27043, 27043);
+
+            var running = await IsRunningAsync(serial);
+            return running ? Result.Success() : Result.Failure("frida-server não iniciou");
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure(ex.Message);
+        }
+    }
+
+    internal async Task<Result<string>> GetServerBinaryNameAsync(string serial)
+    {
+        var props = new[]
+        {
+            await _adb.GetPropAsync(serial, "ro.product.cpu.abi"),
+            await _adb.GetPropAsync(serial, "ro.product.cpu.abilist"),
+            await _adb.GetPropAsync(serial, "ro.product.cpu.arch")
+        };
+
+        string? abi = props.FirstOrDefault(p => p.IsSuccess && !string.IsNullOrWhiteSpace(p.Value))?.Value;
+        abi = abi?.Split(',').FirstOrDefault();
+
+        return abi switch
+        {
+            "arm64-v8a" => Result<string>.Success($"frida-server-{Version}-android-arm64"),
+            "armeabi-v7a" => Result<string>.Success($"frida-server-{Version}-android-arm"),
+            "x86" => Result<string>.Success($"frida-server-{Version}-android-x86"),
+            "x86_64" => Result<string>.Success($"frida-server-{Version}-android-x86_64"),
+            _ => Result<string>.Failure("ABI desconhecida")
+        };
+    }
+
+    private async Task<Result<string>> EnsureBinaryAsync(string name)
+    {
+        var folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FridaDesk", "frida-servers");
+        Directory.CreateDirectory(folder);
+        var path = Path.Combine(folder, name);
+        if (!File.Exists(path))
+        {
+            var url = $"https://github.com/frida/frida/releases/download/{Version}/{name}.xz";
+            using var stream = await _http.GetStreamAsync(url);
+            using var xz = new XZStream(stream);
+            using var file = File.Create(path);
+            await xz.CopyToAsync(file);
+        }
+        return Result<string>.Success(path);
+    }
+
+    private async Task RunAdbAsync(string args)
+    {
+        var run = _runner.Run("adb", args);
+        await foreach (var _ in run.Output) { }
+        await run.WaitForExitAsync();
+    }
+
+    private async Task<bool> IsRunningAsync(string serial)
+    {
+        var run = _runner.Run("adb", $"-s {serial} shell ps -A");
+        var found = false;
+        await foreach (var line in run.Output)
+        {
+            if (line.Line.Contains("frida-server"))
+                found = true;
+        }
+        await run.WaitForExitAsync();
+        return found;
+    }
+}

--- a/tests/FridaHub.Processes.Tests/DevicesViewModelTests.cs
+++ b/tests/FridaHub.Processes.Tests/DevicesViewModelTests.cs
@@ -1,0 +1,85 @@
+using FridaHub.App.ViewModels;
+using FridaHub.Core.Backends;
+using FridaHub.Core.Interfaces;
+using FridaHub.Core.Models;
+using FridaHub.Core.Results;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Xunit;
+
+namespace FridaHub.Processes.Tests;
+
+public class DevicesViewModelTests
+{
+    private class DummyAdb : IAdbBackend
+    {
+        public Task<Result> StartServerAsync() => Task.FromResult(Result.Success());
+        public Task<Result<IEnumerable<DeviceInfo>>> ListDevicesAsync() => Task.FromResult(Result<IEnumerable<DeviceInfo>>.Success(Enumerable.Empty<DeviceInfo>()));
+        public Task<Result<Dictionary<string, string>>> GetPropsAsync(string serial) => Task.FromResult(Result<Dictionary<string, string>>.Success(new()));
+        public Task<Result<string>> GetPropAsync(string serial, string key) => Task.FromResult(Result<string>.Success(""));
+        public Task<Result> ForwardPortsAsync(string serial, int localPort, int remotePort) => Task.FromResult(Result.Success());
+    }
+
+    private class DummyFrida : IFridaBackend
+    {
+        public IAsyncEnumerable<ProcessLine> RunCodeshareAsync(string author, string slug, string package, string? selector = null, CancellationToken cancellationToken = default)
+        {
+            return Empty();
+            static async IAsyncEnumerable<ProcessLine> Empty()
+            {
+                yield break;
+            }
+        }
+        public IAsyncEnumerable<ProcessLine> RunLocalScriptAsync(string scriptPath, string package, string? selector = null, CancellationToken cancellationToken = default)
+        {
+            return Empty();
+            static async IAsyncEnumerable<ProcessLine> Empty()
+            {
+                yield break;
+            }
+        }
+        public Task<Result<IEnumerable<string>>> ListProcessesAsync(string? deviceSerial = null, CancellationToken cancellationToken = default) => Task.FromResult(Result<IEnumerable<string>>.Success(Enumerable.Empty<string>()));
+    }
+
+    private class DummyDiag : IDiagnosticsService
+    {
+        public string? LastError => null;
+        public ObservableCollection<string> LastCommands { get; } = new();
+        public TimeSpan? LastAttachTime => null;
+        public TimeSpan? LastSpawnTime => null;
+        public ObservableCollection<DeviceInfo> LastDevices { get; } = new();
+        public void RecordError(string message) { }
+        public void RecordCommand(string command) { }
+        public void RecordAttachTime(TimeSpan duration) { }
+        public void RecordSpawnTime(TimeSpan duration) { }
+        public void RecordDevices(IEnumerable<DeviceInfo> devices) { }
+        public string ExportReport(string directory, bool markdown) => string.Empty;
+    }
+
+    private class FakeInstaller : IFridaInstaller
+    {
+        private readonly bool _ok;
+        public FakeInstaller(bool ok) => _ok = ok;
+        public Task<Result> InstallAsync(string serial) => Task.FromResult(_ok ? Result.Success() : Result.Failure("erro"));
+    }
+
+    [Fact]
+    public async Task StatusAtualizaAposInstalacao()
+    {
+        var device = new DeviceInfo { Serial = "123" };
+        var vm = new DevicesViewModel(new DummyAdb(), new DummyFrida(), new DummyDiag(), new FakeInstaller(true));
+        await vm.InstallFridaCommand.ExecuteAsync(device);
+        Assert.Equal(FridaStatus.Ready, device.Status);
+    }
+
+    [Fact]
+    public async Task StatusErroQuandoFalha()
+    {
+        var device = new DeviceInfo { Serial = "123" };
+        var vm = new DevicesViewModel(new DummyAdb(), new DummyFrida(), new DummyDiag(), new FakeInstaller(false));
+        await vm.InstallFridaCommand.ExecuteAsync(device);
+        Assert.Equal(FridaStatus.Error, device.Status);
+    }
+}

--- a/tests/FridaHub.Processes.Tests/FridaHub.Processes.Tests.csproj
+++ b/tests/FridaHub.Processes.Tests/FridaHub.Processes.Tests.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\FridaHub.Processes\FridaHub.Processes.csproj" />
     <ProjectReference Include="..\..\src\FridaHub.Infrastructure\FridaHub.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\FridaHub.App\FridaHub.App.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/FridaHub.Processes.Tests/FridaInstallerTests.cs
+++ b/tests/FridaHub.Processes.Tests/FridaInstallerTests.cs
@@ -1,0 +1,39 @@
+using FridaHub.Core.Backends;
+using FridaHub.Core.Interfaces;
+using FridaHub.Core.Models;
+using FridaHub.Core.Results;
+using FridaHub.Processes;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FridaHub.Processes.Tests;
+
+public class FridaInstallerTests
+{
+    private class FakeAdb : IAdbBackend
+    {
+        private readonly string _abi;
+        public FakeAdb(string abi) => _abi = abi;
+        public Task<Result> StartServerAsync() => Task.FromResult(Result.Success());
+        public Task<Result<IEnumerable<DeviceInfo>>> ListDevicesAsync() => Task.FromResult(Result<IEnumerable<DeviceInfo>>.Success(Enumerable.Empty<DeviceInfo>()));
+        public Task<Result<Dictionary<string, string>>> GetPropsAsync(string serial) => Task.FromResult(Result<Dictionary<string, string>>.Success(new()));
+        public Task<Result<string>> GetPropAsync(string serial, string key) => Task.FromResult(Result<string>.Success(_abi));
+        public Task<Result> ForwardPortsAsync(string serial, int localPort, int remotePort) => Task.FromResult(Result.Success());
+    }
+
+    [Theory]
+    [InlineData("arm64-v8a", "frida-server-16.7.7-android-arm64")]
+    [InlineData("armeabi-v7a", "frida-server-16.7.7-android-arm")]
+    [InlineData("x86", "frida-server-16.7.7-android-x86")]
+    [InlineData("x86_64", "frida-server-16.7.7-android-x86_64")]
+    public async Task EscolheBinarioCorreto(string abi, string esperado)
+    {
+        var adb = new FakeAdb(abi);
+        var installer = new FridaInstaller(adb, new ProcessRunner(), new HttpClient(new HttpClientHandler()));
+        var result = await installer.GetServerBinaryNameAsync("abc");
+        Assert.True(result.IsSuccess);
+        Assert.Equal(esperado, result.Value);
+    }
+}


### PR DESCRIPTION
## Resumo
- Detecta ABI via ADB e baixa binário frida-server 16.7.7 adequado
- Instala e inicia frida-server no dispositivo, encaminhando portas necessárias
- Atualiza UI com status de instalação e comando para instalar
