### PR TITLE
feat: estilo unificado e scripts de publicação

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Build outputs
 bin/
 obj/
+build/publish/

--- a/build/publish-linux.sh
+++ b/build/publish-linux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Autor: Pexe - Instagram: David.devloli
+set -e
+RID=linux-x64
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dotnet publish "$SCRIPT_DIR/../src/FridaHub.App/FridaHub.App.csproj" -c Release -r $RID -p:PublishSingleFile=true -p:SelfContained=true -o "$SCRIPT_DIR/publish/$RID"

--- a/build/publish-macos.sh
+++ b/build/publish-macos.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Autor: Pexe - Instagram: David.devloli
+set -e
+RID=osx-x64
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dotnet publish "$SCRIPT_DIR/../src/FridaHub.App/FridaHub.App.csproj" -c Release -r $RID -p:PublishSingleFile=true -p:SelfContained=true -o "$SCRIPT_DIR/publish/$RID"

--- a/build/publish-win.ps1
+++ b/build/publish-win.ps1
@@ -1,0 +1,7 @@
+param(
+    [string]$RID = "win-x64"
+)
+# Autor: Pexe - Instagram: David.devloli
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$OutputDir = Join-Path $ScriptDir "publish/$RID"
+dotnet publish "$ScriptDir/../src/FridaHub.App/FridaHub.App.csproj" -c Release -r $RID -p:PublishSingleFile=true -p:SelfContained=true -o $OutputDir

--- a/src/FridaHub.App/App.axaml
+++ b/src/FridaHub.App/App.axaml
@@ -4,5 +4,67 @@
              RequestedThemeVariant="Dark">
     <Application.Styles>
         <FluentTheme/>
+
+        <Styles>
+            <!-- Tipografia -->
+            <Style Selector="TextBlock">
+                <Setter Property="FontFamily" Value="Inter, Segoe UI, Roboto"/>
+            </Style>
+            <Style Selector="TextBlock.h1">
+                <Setter Property="FontSize" Value="24"/>
+            </Style>
+            <Style Selector="TextBlock.h2">
+                <Setter Property="FontSize" Value="20"/>
+            </Style>
+            <Style Selector="TextBlock.h3">
+                <Setter Property="FontSize" Value="16"/>
+            </Style>
+            <Style Selector="TextBlock.body">
+                <Setter Property="FontSize" Value="14"/>
+            </Style>
+            <Style Selector="TextBlock.caption">
+                <Setter Property="FontSize" Value="12"/>
+            </Style>
+
+            <!-- Cartões e chips -->
+            <Style Selector="Border.card">
+                <Setter Property="CornerRadius" Value="16"/>
+                <Setter Property="Padding" Value="16"/>
+                <Setter Property="Background" Value="{DynamicResource SurfaceVariantBrush}"/>
+                <Setter Property="BoxShadow" Value="0 2 10 0 #40000000"/>
+            </Style>
+
+            <Style Selector="Border.chip">
+                <Setter Property="Background" Value="{DynamicResource PrimaryBrush}"/>
+                <Setter Property="CornerRadius" Value="8"/>
+                <Setter Property="Padding" Value="4,2"/>
+                <Setter Property="Margin" Value="8,0,0,0"/>
+            </Style>
+            <Style Selector="Border.chip TextBlock">
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="FontSize" Value="12"/>
+            </Style>
+        </Styles>
     </Application.Styles>
+
+    <Application.Resources>
+        <!-- Paleta escura -->
+        <Color x:Key="PrimaryColor">#4F46E5</Color>
+        <SolidColorBrush x:Key="PrimaryBrush" Color="{DynamicResource PrimaryColor}"/>
+
+        <Color x:Key="SuccessColor">#16A34A</Color>
+        <SolidColorBrush x:Key="SuccessBrush" Color="{DynamicResource SuccessColor}"/>
+
+        <Color x:Key="WarningColor">#F59E0B</Color>
+        <SolidColorBrush x:Key="WarningBrush" Color="{DynamicResource WarningColor}"/>
+
+        <Color x:Key="ErrorColor">#DC2626</Color>
+        <SolidColorBrush x:Key="ErrorBrush" Color="{DynamicResource ErrorColor}"/>
+
+        <Color x:Key="SurfaceColor">#111827</Color>
+        <SolidColorBrush x:Key="SurfaceBrush" Color="{DynamicResource SurfaceColor}"/>
+
+        <Color x:Key="SurfaceVariantColor">#1F2937</Color>
+        <SolidColorBrush x:Key="SurfaceVariantBrush" Color="{DynamicResource SurfaceVariantColor}"/>
+    </Application.Resources>
 </Application>

--- a/src/FridaHub.App/Views/DevicesView.axaml
+++ b/src/FridaHub.App/Views/DevicesView.axaml
@@ -16,23 +16,20 @@
         <ListBox ItemsSource="{Binding Devices}">
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="models:DeviceInfo">
-                    <Border Margin="0,0,0,8" Padding="8" BorderThickness="1" BorderBrush="Gray" CornerRadius="4">
+                    <Border Margin="0,0,0,8" Classes="card">
                         <StackPanel Spacing="8">
                             <StackPanel Orientation="Horizontal" Spacing="8">
                                 <StackPanel>
-                                    <TextBlock Text="{Binding Model}" FontWeight="Bold"/>
-                                    <TextBlock Text="{Binding Serial}" FontSize="10" Foreground="Gray"/>
+                                    <TextBlock Text="{Binding Model}" FontWeight="Bold" Classes="h3"/>
+                                    <TextBlock Text="{Binding Serial}" Classes="caption" Foreground="Gray"/>
                                 </StackPanel>
-                                <Border Background="LightGray" Padding="4" CornerRadius="4" Margin="8,0,0,0" IsVisible="{Binding IsEmulator}">
-                                    <TextBlock Text="Emulador" FontSize="10"/>
+                                <Border Classes="chip" IsVisible="{Binding IsEmulator}">
+                                    <TextBlock Text="Emulador"/>
                                 </Border>
-                                <Border Background="LightGray"
-                                        Padding="4"
-                                        CornerRadius="4"
-                                        Margin="8,0,0,0"
+                                <Border Classes="chip"
                                         IsVisible="{Binding Platform, Converter={StaticResource IosVisibilityConverter}}">
                                     <!-- TODO(Jailbreak): implementar suporte futuro de forma segura e autorizada -->
-                                    <TextBlock Text="Jailbreak (futuro)" FontSize="10"/>
+                                    <TextBlock Text="Jailbreak (futuro)"/>
                                 </Border>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal" Spacing="4">

--- a/src/FridaHub.App/Views/ScriptsView.axaml
+++ b/src/FridaHub.App/Views/ScriptsView.axaml
@@ -14,11 +14,11 @@
         <ListBox ItemsSource="{Binding Scripts}">
             <ListBox.ItemTemplate>
                 <DataTemplate x:DataType="models:ScriptRef">
-                    <Border Margin="0,0,0,8" Padding="8" BorderThickness="1" BorderBrush="Gray" CornerRadius="4">
+                    <Border Margin="0,0,0,8" Classes="card">
                         <StackPanel>
-                            <TextBlock Text="{Binding Title}" FontWeight="Bold"/>
-                            <TextBlock Text="{Binding Author}" FontStyle="Italic"/>
-                            <TextBlock Text="{Binding Source}" FontSize="10" Foreground="Gray"/>
+                            <TextBlock Text="{Binding Title}" FontWeight="Bold" Classes="h3"/>
+                            <TextBlock Text="{Binding Author}" FontStyle="Italic" Classes="body"/>
+                            <TextBlock Text="{Binding Source}" Classes="caption" Foreground="Gray"/>
                         </StackPanel>
                     </Border>
                 </DataTemplate>


### PR DESCRIPTION
## Resumo
- aplica tipografia, paleta escura e estilos de cartão/chip
- padroniza fontes em DevicesView e ScriptsView
- adiciona scripts de publicação single-file para Windows, Linux e macOS

## Testes
- `dotnet test`
- `./build/publish-linux.sh`
- `timeout 5 ./build/publish/linux-x64/FridaHub.App` *(falha: libSkiaSharp ausente)*

------
https://chatgpt.com/codex/tasks/task_b_68a7ef33fb448322bd812a205d59a15a