### PR TITLE
Corrige inicialização da janela principal

### DIFF
--- a/src/FridaHub.App/App.axaml.cs
+++ b/src/FridaHub.App/App.axaml.cs
@@ -23,6 +23,11 @@ public partial class App : Application
             var mainView = Services.GetRequiredService<MainView>();
             desktop.MainWindow = mainView;
         }
+        else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
+        {
+            var mainView = Services.GetRequiredService<MainView>();
+            singleView.MainView = mainView;
+        }
 
         base.OnFrameworkInitializationCompleted();
     }


### PR DESCRIPTION
## Resumo
- garante que a janela principal seja exibida também quando a aplicação usa `ISingleViewApplicationLifetime`

## Testes
- `dotnet test`
