### PR TITLE
Corrige fontes do ImGui e usa ClientSize

### DIFF
--- a/src/FridaHub.ImGuiApp/ImGuiController.cs
+++ b/src/FridaHub.ImGuiApp/ImGuiController.cs
@@ -11,13 +11,24 @@ public class ImGuiController : IDisposable
 {
     private int _width;
     private int _height;
+    private int _fontTexture;
 
     public ImGuiController(int width, int height)
     {
         _width = width;
         _height = height;
         ImGui.CreateContext();
-        ImGui.GetIO().Fonts.AddFontDefault();
+        var io = ImGui.GetIO();
+        io.Fonts.AddFontDefault();
+        io.Fonts.GetTexDataAsRGBA32(out IntPtr pixels, out int fontWidth, out int fontHeight, out _);
+        _fontTexture = GL.GenTexture();
+        GL.BindTexture(TextureTarget.Texture2D, _fontTexture);
+        GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
+        GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, fontWidth, fontHeight, 0,
+            PixelFormat.Rgba, PixelType.UnsignedByte, pixels);
+        io.Fonts.SetTexID((IntPtr)_fontTexture);
+        io.Fonts.ClearTexData();
     }
 
     public void Update(GameWindow window, float deltaSeconds)
@@ -42,5 +53,7 @@ public class ImGuiController : IDisposable
 
     public void Dispose()
     {
+        if (_fontTexture != 0)
+            GL.DeleteTexture(_fontTexture);
     }
 }

--- a/src/FridaHub.ImGuiApp/MainWindow.cs
+++ b/src/FridaHub.ImGuiApp/MainWindow.cs
@@ -25,7 +25,7 @@ public class MainWindow : GameWindow
 
     public MainWindow(IServiceProvider provider) : base(GameWindowSettings.Default, new NativeWindowSettings
     {
-        Size = new Vector2i(1280, 720),
+        ClientSize = new Vector2i(1280, 720),
         Title = "FridaDesk - Painel"
     })
     {


### PR DESCRIPTION
## Resumo
- Garante a construção do atlas de fontes no ImGui e associa textura ao OpenGL
- Substitui propriedade Size por ClientSize em NativeWindowSettings

## Testes
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_b_68a7f7e18d80832296c8739b631150c3