### PR TITLE
Corrige XAML do MainWindow

### DIFF
--- a/src/FridaHub.App/Views/MainWindow.axaml
+++ b/src/FridaHub.App/Views/MainWindow.axaml
@@ -1,26 +1,16 @@
-using System.Windows.Input;
-using CommunityToolkit.Mvvm.ComponentModel;
-using Microsoft.Extensions.DependencyInjection;
-using CommunityToolkit.Mvvm.Input;
-using FridaHub.App.Views;
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:FridaHub.App.ViewModels"
+        x:Class="FridaHub.App.Views.MainWindow"
+        x:DataType="vm:MainWindowViewModel">
+    <!-- Autor: Pexe (instagram David.devloli) -->
+    <DockPanel>
+        <Button DockPanel.Dock="Bottom"
+                Content="{Binding CurrentButtonLabel}"
+                Command="{Binding NextPage}"
+                HorizontalAlignment="Right"
+                Margin="10"/>
+        <ContentControl Content="{Binding CurrentPage}"/>
+    </DockPanel>
+</Window>
 
-namespace FridaHub.App.ViewModels;
-
-// Autor: Pexe (instagram David.devloli)
-public partial class MainWindowViewModel : ObservableObject
-{
-    [ObservableProperty]
-    private object? currentPage;
-
-    [ObservableProperty]
-    private string currentButtonLabel = string.Empty;
-
-    public ICommand NextPage { get; }
-
-    public MainWindowViewModel()
-    {
-        currentPage = App.Services.GetRequiredService<MainView>();
-        currentButtonLabel = "Iniciar";
-        NextPage = new RelayCommand(() => { /* navegação futura */ });
-    }
-}


### PR DESCRIPTION
## Resumo
- Corrige arquivo MainWindow.axaml substituindo código C# inválido por marcação Avalonia válida
- Adiciona botão para navegação e ContentControl ligado à página atual

## Testes
- `dotnet build src/FridaHub.App/FridaHub.App.csproj`
- `dotnet test`

