### PR TITLE
feat: interface para gerenciar dispositivos e instalar frida-server

### DIFF
--- a/src/FridaDesk.Wpf/Controls/StatusBadge.xaml
+++ b/src/FridaDesk.Wpf/Controls/StatusBadge.xaml
@@ -2,7 +2,7 @@
 <UserControl x:Class="FridaDesk.Wpf.Controls.StatusBadge"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Border Background="Gray" Padding="4" CornerRadius="4">
-        <TextBlock Foreground="White" Text="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+    <Border x:Name="BadgeBorder" Padding="4" CornerRadius="4" Background="Orange">
+        <TextBlock x:Name="BadgeText" Foreground="White" />
     </Border>
 </UserControl>

--- a/src/FridaDesk.Wpf/Controls/StatusBadge.xaml.cs
+++ b/src/FridaDesk.Wpf/Controls/StatusBadge.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
+using FridaHub.Core.Models;
 
 namespace FridaDesk.Wpf.Controls;
 
@@ -9,14 +11,45 @@ public partial class StatusBadge : UserControl
     public StatusBadge()
     {
         InitializeComponent();
+        UpdateVisual();
     }
 
-    public string Text
+    public FridaStatus Status
     {
-        get => (string)GetValue(TextProperty);
-        set => SetValue(TextProperty, value);
+        get => (FridaStatus)GetValue(StatusProperty);
+        set => SetValue(StatusProperty, value);
     }
 
-    public static readonly DependencyProperty TextProperty =
-        DependencyProperty.Register(nameof(Text), typeof(string), typeof(StatusBadge), new PropertyMetadata(string.Empty));
+    public static readonly DependencyProperty StatusProperty =
+        DependencyProperty.Register(nameof(Status), typeof(FridaStatus), typeof(StatusBadge), new PropertyMetadata(FridaStatus.NotInstalled, OnStatusChanged));
+
+    private static void OnStatusChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        => ((StatusBadge)d).UpdateVisual();
+
+    private void UpdateVisual()
+    {
+        string text;
+        Brush brush;
+        switch (Status)
+        {
+            case FridaStatus.Ready:
+                text = "pronto";
+                brush = Brushes.Green;
+                break;
+            case FridaStatus.Error:
+                text = "erro";
+                brush = Brushes.Red;
+                break;
+            case FridaStatus.Installing:
+                text = "instalando";
+                brush = Brushes.Gray;
+                break;
+            default:
+                text = "não iniciado";
+                brush = Brushes.Orange;
+                break;
+        }
+        BadgeBorder.Background = brush;
+        BadgeText.Text = text;
+    }
 }

--- a/src/FridaDesk.Wpf/Extensions/FridaInstallerExtensions.cs
+++ b/src/FridaDesk.Wpf/Extensions/FridaInstallerExtensions.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using FridaHub.Core.Interfaces;
+using FridaHub.Core.Results;
+
+namespace FridaDesk.Wpf.Extensions;
+
+// Autor: Pexe (instagram David.devloli)
+public static class FridaInstallerExtensions
+{
+    public static Task<Result> EnsureAsync(this IFridaInstaller installer, string serial)
+        => installer.InstallAsync(serial);
+}

--- a/src/FridaDesk.Wpf/MainWindow.xaml
+++ b/src/FridaDesk.Wpf/MainWindow.xaml
@@ -2,14 +2,7 @@
 <Window x:Class="FridaDesk.Wpf.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:views="clr-namespace:FridaDesk.Wpf.Views"
-        xmlns:vm="clr-namespace:FridaDesk.Wpf.ViewModels"
         Title="FridaDesk" Height="450" Width="800">
-    <Window.Resources>
-        <DataTemplate DataType="{x:Type vm:DevicesViewModel}">
-            <views:DevicesView />
-        </DataTemplate>
-    </Window.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="200"/>
@@ -23,7 +16,7 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Row="0">
-                <Button Content="Devices" Command="{Binding ShowDevicesCommand}" />
+                <Button Content="Devices" Command="{Binding NavigateDevicesCommand}" />
                 <Button Content="Scripts" IsEnabled="False" />
                 <Button Content="Execuções" IsEnabled="False" />
                 <Button Content="Configurações" IsEnabled="False" />
@@ -32,6 +25,6 @@
             <ListBox Grid.Row="1" ItemsSource="{Binding ConsoleLines}" Background="{StaticResource SidebarBackgroundBrush}" Foreground="{StaticResource ForegroundBrush}" />
         </Grid>
 
-        <ContentControl Grid.Column="1" Content="{Binding CurrentViewModel}" />
+        <ContentControl Grid.Column="1" Content="{Binding CurrentView}" />
     </Grid>
 </Window>

--- a/src/FridaDesk.Wpf/Services/ServiceProviderFactory.cs
+++ b/src/FridaDesk.Wpf/Services/ServiceProviderFactory.cs
@@ -34,6 +34,7 @@ public static class ServiceProviderFactory
 
         services.AddSingleton<MainViewModel>();
         services.AddSingleton<DevicesViewModel>();
+        services.AddSingleton<DevicesView>();
 
         services.AddTransient<MainWindow>();
 

--- a/src/FridaDesk.Wpf/ViewModels/MainViewModel.cs
+++ b/src/FridaDesk.Wpf/ViewModels/MainViewModel.cs
@@ -1,25 +1,28 @@
 using System.Collections.ObjectModel;
+using System.Windows.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using FridaDesk.Wpf.Views;
 
 namespace FridaDesk.Wpf.ViewModels;
 
 // Autor: Pexe (instagram David.devloli)
 public partial class MainViewModel : ObservableObject
 {
-    public DevicesViewModel DevicesViewModel { get; }
+    public DevicesView DevicesView { get; }
 
     [ObservableProperty]
-    private ObservableObject currentViewModel;
+    private UserControl currentView;
 
     public ObservableCollection<string> ConsoleLines { get; } = new();
 
-    public MainViewModel(DevicesViewModel devicesViewModel)
+    public MainViewModel(DevicesView devicesView, DevicesViewModel devicesViewModel)
     {
-        DevicesViewModel = devicesViewModel;
-        currentViewModel = devicesViewModel;
+        DevicesView = devicesView;
+        DevicesView.DataContext = devicesViewModel;
+        currentView = devicesView;
     }
 
     [RelayCommand]
-    private void ShowDevices() => CurrentViewModel = DevicesViewModel;
+    private void NavigateDevices() => CurrentView = DevicesView;
 }

--- a/src/FridaDesk.Wpf/Views/DevicesView.xaml
+++ b/src/FridaDesk.Wpf/Views/DevicesView.xaml
@@ -4,13 +4,36 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:FridaDesk.Wpf.Controls">
     <StackPanel Margin="10">
-        <TextBlock Text="Dispositivos" FontSize="16" FontWeight="Bold"/>
-        <ItemsControl ItemsSource="{Binding Devices}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <controls:StatusBadge Text="{Binding}"/>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
+        <Button Content="Atualizar" Command="{Binding RefreshAsyncCommand}" Width="120" Margin="0,0,0,10" />
+        <ListView ItemsSource="{Binding Devices}">
+            <ListView.View>
+                <GridView>
+                    <GridViewColumn Header="Serial" DisplayMemberBinding="{Binding Serial}" />
+                    <GridViewColumn Header="Modelo" DisplayMemberBinding="{Binding Model}" />
+                    <GridViewColumn Header="Emulador" DisplayMemberBinding="{Binding IsEmulator}" />
+                    <GridViewColumn Header="Status">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <controls:StatusBadge Status="{Binding Status}" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Header="Ações">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Content="Instalar frida-server"
+                                            Command="{Binding DataContext.EnsureFridaAsyncCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                            CommandParameter="{Binding}" Margin="0,0,5,0" />
+                                    <Button Content="Executar"
+                                            Command="{Binding DataContext.RunAsyncCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                            CommandParameter="{Binding}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                </GridView>
+            </ListView.View>
+        </ListView>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
## Resumo
- implementa `CurrentView` no `MainViewModel` com comando de navegação
- adiciona `DevicesViewModel` com listagem de dispositivos e instalação do frida-server
- cria `DevicesView` com botão de atualização, tabela e ações
- inclui `StatusBadge` colorido para indicar estado da instalação

## Testes
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_b_68aa65b83f00832292da8b5d44975944