### PR TITLE
Cria solução FridaDesk com aplicativo Avalonia e design system

### DIFF
--- a/FridaDesk.sln
+++ b/FridaDesk.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{98B38DB1-3688-4605-9403-394450ECD9A9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FridaDesk.App", "src\FridaDesk.App\FridaDesk.App.csproj", "{9D77638E-6B04-4359-9858-796665D97B80}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FridaDesk.UI", "src\FridaDesk.UI\FridaDesk.UI.csproj", "{4166CDAF-BCA7-4D04-81A0-F8C1B801205F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FridaDesk.Mock", "src\FridaDesk.Mock\FridaDesk.Mock.csproj", "{5ED4FA71-2385-4258-A171-B097A6CA063E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9D77638E-6B04-4359-9858-796665D97B80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D77638E-6B04-4359-9858-796665D97B80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D77638E-6B04-4359-9858-796665D97B80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D77638E-6B04-4359-9858-796665D97B80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4166CDAF-BCA7-4D04-81A0-F8C1B801205F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4166CDAF-BCA7-4D04-81A0-F8C1B801205F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4166CDAF-BCA7-4D04-81A0-F8C1B801205F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4166CDAF-BCA7-4D04-81A0-F8C1B801205F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ED4FA71-2385-4258-A171-B097A6CA063E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ED4FA71-2385-4258-A171-B097A6CA063E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ED4FA71-2385-4258-A171-B097A6CA063E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ED4FA71-2385-4258-A171-B097A6CA063E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9D77638E-6B04-4359-9858-796665D97B80} = {98B38DB1-3688-4605-9403-394450ECD9A9}
+		{4166CDAF-BCA7-4D04-81A0-F8C1B801205F} = {98B38DB1-3688-4605-9403-394450ECD9A9}
+		{5ED4FA71-2385-4258-A171-B097A6CA063E} = {98B38DB1-3688-4605-9403-394450ECD9A9}
+	EndGlobalSection
+EndGlobal

--- a/src/FridaDesk.App/App.axaml
+++ b/src/FridaDesk.App/App.axaml
@@ -1,0 +1,9 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FridaDesk.App.App"
+             RequestedThemeVariant="Dark">
+    <Application.Styles>
+        <FluentTheme/>
+        <StyleInclude Source="avares://FridaDesk.UI/Styles/Theme.xaml"/>
+    </Application.Styles>
+</Application>

--- a/src/FridaDesk.App/App.axaml.cs
+++ b/src/FridaDesk.App/App.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace FridaDesk.App;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/FridaDesk.App/FridaDesk.App.csproj
+++ b/src/FridaDesk.App/FridaDesk.App.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.4" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.4" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.4">
+      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
+      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FridaDesk.UI\FridaDesk.UI.csproj" />
+    <ProjectReference Include="..\FridaDesk.Mock\FridaDesk.Mock.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FridaDesk.App/MainWindow.axaml
+++ b/src/FridaDesk.App/MainWindow.axaml
@@ -1,0 +1,9 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="FridaDesk.App.MainWindow"
+        Title="FridaDesk (Design Preview)">
+    <Grid />
+</Window>

--- a/src/FridaDesk.App/MainWindow.axaml.cs
+++ b/src/FridaDesk.App/MainWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace FridaDesk.App;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/FridaDesk.App/Program.cs
+++ b/src/FridaDesk.App/Program.cs
@@ -1,0 +1,24 @@
+﻿using Avalonia;
+using Avalonia.ReactiveUI;
+using System;
+
+namespace FridaDesk.App;
+
+class Program
+{
+    // Initialization code. Don't use any Avalonia, third-party APIs or any
+    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+    // yet and stuff might break.
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .UseReactiveUI()
+            .LogToTrace();
+}
+

--- a/src/FridaDesk.App/app.manifest
+++ b/src/FridaDesk.App/app.manifest
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="FridaDesk.App.Desktop"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>
+

--- a/src/FridaDesk.Mock/Class1.cs
+++ b/src/FridaDesk.Mock/Class1.cs
@@ -1,0 +1,7 @@
+﻿namespace FridaDesk.Mock;
+
+public class Class1
+{
+
+}
+

--- a/src/FridaDesk.Mock/FridaDesk.Mock.csproj
+++ b/src/FridaDesk.Mock/FridaDesk.Mock.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FridaDesk.UI/Class1.cs
+++ b/src/FridaDesk.UI/Class1.cs
@@ -1,0 +1,7 @@
+﻿namespace FridaDesk.UI;
+
+public class Class1
+{
+
+}
+

--- a/src/FridaDesk.UI/FridaDesk.UI.csproj
+++ b/src/FridaDesk.UI/FridaDesk.UI.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AvaloniaResource Include="Styles/Theme.xaml" />
+  </ItemGroup>
+
+</Project>

--- a/src/FridaDesk.UI/Styles/Theme.xaml
+++ b/src/FridaDesk.UI/Styles/Theme.xaml
@@ -1,0 +1,101 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Styles.Resources>
+        <!-- Colors -->
+        <Color x:Key="PrimaryColor">#4F46E5</Color>
+        <Color x:Key="SuccessColor">#16A34A</Color>
+        <Color x:Key="WarningColor">#F59E0B</Color>
+        <Color x:Key="ErrorColor">#DC2626</Color>
+
+        <Color x:Key="SurfaceRootColor">#0B1020</Color>
+        <Color x:Key="SurfaceWindowColor">#111827</Color>
+        <Color x:Key="SurfaceCardColor">#1F2937</Color>
+        <Color x:Key="SurfaceBorderColor">#374151</Color>
+
+        <!-- Brushes -->
+        <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}"/>
+        <SolidColorBrush x:Key="BrushOk" Color="{StaticResource SuccessColor}"/>
+        <SolidColorBrush x:Key="BrushWarn" Color="{StaticResource WarningColor}"/>
+        <SolidColorBrush x:Key="BrushError" Color="{StaticResource ErrorColor}"/>
+        <SolidColorBrush x:Key="BrushMuted" Color="{StaticResource SurfaceBorderColor}"/>
+
+        <SolidColorBrush x:Key="SurfaceRootBrush" Color="{StaticResource SurfaceRootColor}"/>
+        <SolidColorBrush x:Key="SurfaceWindowBrush" Color="{StaticResource SurfaceWindowColor}"/>
+        <SolidColorBrush x:Key="SurfaceCardBrush" Color="{StaticResource SurfaceCardColor}"/>
+        <SolidColorBrush x:Key="SurfaceBorderBrush" Color="{StaticResource SurfaceBorderColor}"/>
+
+        <!-- Radii -->
+        <CornerRadius x:Key="CornerRadiusS">8</CornerRadius>
+        <CornerRadius x:Key="CornerRadiusM">12</CornerRadius>
+        <CornerRadius x:Key="CornerRadiusL">16</CornerRadius>
+
+        <!-- Shadows -->
+        <DropShadowEffect x:Key="ShadowSoft" BlurRadius="4" Color="#000000" Opacity="0.25" OffsetX="0" OffsetY="2"/>
+        <DropShadowEffect x:Key="ShadowElevated" BlurRadius="8" Color="#000000" Opacity="0.35" OffsetX="0" OffsetY="4"/>
+
+        <!-- Spacing -->
+        <Thickness x:Key="Space4">4</Thickness>
+        <Thickness x:Key="Space8">8</Thickness>
+        <Thickness x:Key="Space12">12</Thickness>
+        <Thickness x:Key="Space16">16</Thickness>
+        <Thickness x:Key="Space24">24</Thickness>
+
+        <!-- Typography -->
+        <FontFamily x:Key="FontInter">avares://Avalonia.Fonts.Inter#Inter</FontFamily>
+        <x:Double x:Key="FontSize12">12</x:Double>
+        <x:Double x:Key="FontSize14">14</x:Double>
+        <x:Double x:Key="FontSize16">16</x:Double>
+        <x:Double x:Key="FontSize20">20</x:Double>
+        <x:Double x:Key="FontSize24">24</x:Double>
+
+        <!-- Icons -->
+        <PathIcon x:Key="PlaceholderIcon" Data="M2,2 L14,2 L14,14 L2,14 Z" Width="16" Height="16" Foreground="{StaticResource PrimaryBrush}"/>
+    </Styles.Resources>
+
+    <Style Selector="TextBlock">
+        <Setter Property="FontFamily" Value="{StaticResource FontInter}"/>
+        <Setter Property="Foreground" Value="White"/>
+    </Style>
+
+    <Style Selector="Window">
+        <Setter Property="Background" Value="{StaticResource SurfaceWindowBrush}"/>
+    </Style>
+
+    <!-- Controls styling -->
+    <Style Selector="Button">
+        <Setter Property="Background" Value="{StaticResource PrimaryBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="BorderBrush" Value="{StaticResource SurfaceBorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="CornerRadius" Value="{StaticResource CornerRadiusM}"/>
+    </Style>
+
+    <Style Selector="TextBox">
+        <Setter Property="Background" Value="{StaticResource SurfaceCardBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="BorderBrush" Value="{StaticResource SurfaceBorderBrush}"/>
+        <Setter Property="CornerRadius" Value="{StaticResource CornerRadiusS}"/>
+    </Style>
+
+    <Style Selector="ComboBox">
+        <Setter Property="Background" Value="{StaticResource SurfaceCardBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Setter Property="BorderBrush" Value="{StaticResource SurfaceBorderBrush}"/>
+        <Setter Property="CornerRadius" Value="{StaticResource CornerRadiusS}"/>
+    </Style>
+
+    <Style Selector="TabControl">
+        <Setter Property="Background" Value="{StaticResource SurfaceWindowBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+    </Style>
+
+    <Style Selector="ListBox">
+        <Setter Property="Background" Value="{StaticResource SurfaceWindowBrush}"/>
+        <Setter Property="Foreground" Value="White"/>
+    </Style>
+
+    <Style Selector="ScrollBar">
+        <Setter Property="Background" Value="{StaticResource SurfaceCardBrush}"/>
+        <Setter Property="Foreground" Value="{StaticResource PrimaryBrush}"/>
+    </Style>
+</Styles>


### PR DESCRIPTION
## Resumo
- Adiciona solution FridaDesk com projetos App, UI e Mock
- Implementa app Avalonia com janela de preview
- Cria design system dark com tema e estilos base

## Testes
- `dotnet build FridaDesk.sln`
- `dotnet run --project src/FridaDesk.App` *(falhou: XOpenDisplay failed)*

Autor: Pexe (instagram David.devloli)

------
https://chatgpt.com/codex/tasks/task_b_68aa79c602d08322851cd493ee0f358d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novos recursos
  - Primeiro shell do app desktop (preview) com janela principal.
  - Tema escuro padrão, tipografia Inter e tema Fluent.
  - Estilos consistentes para Botão, TextBox, ComboBox, TabControl, ListBox e ScrollBar.
  - Inicialização em modo desktop clássico com detecção de plataforma.

- Compatibilidade
  - Manifesto para Windows 10+ garantindo melhor comportamento de janelas e transparência.

- Tarefas
  - Criação da solução e estrutura de projetos com dependências de UI configuradas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->