### PR TITLE
Adiciona shell e views mockadas do FridaDesk

### DIFF
--- a/src/FridaDesk.UI/Controls/Card.axaml
+++ b/src/FridaDesk.UI/Controls/Card.axaml
@@ -1,0 +1,10 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FridaDesk.UI.Controls.Card">
+    <Border x:Name="PART_Border" Background="{StaticResource SurfaceCardBrush}" CornerRadius="{StaticResource CornerRadiusM}" Padding="{StaticResource Space16}" Effect="{StaticResource ShadowSoft}">
+        <StackPanel>
+            <ContentPresenter x:Name="HeaderPresenter" Content="{Binding Header, RelativeSource={RelativeSource AncestorType=UserControl}}" Margin="0,0,0,8"/>
+            <ContentPresenter Content="{Binding Content, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/src/FridaDesk.UI/Controls/Card.axaml.cs
+++ b/src/FridaDesk.UI/Controls/Card.axaml.cs
@@ -1,0 +1,28 @@
+// Autor: Pexe (Instagram: David.devloli)
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace FridaDesk.UI.Controls;
+
+public partial class Card : UserControl
+{
+    public static readonly StyledProperty<object?> HeaderProperty =
+        AvaloniaProperty.Register<Card, object?>(nameof(Header));
+
+    public object? Header
+    {
+        get => GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
+    }
+
+    public Card()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/FridaDesk.UI/Controls/ConsolePanel.axaml
+++ b/src/FridaDesk.UI/Controls/ConsolePanel.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FridaDesk.UI.Controls.ConsolePanel">
+    <Border Background="{StaticResource SurfaceCardBrush}" Padding="8">
+        <Grid RowDefinitions="Auto,*">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Content="Copiar" Click="OnCopy"/>
+                <Button Content="Limpar" Click="OnClear"/>
+            </StackPanel>
+            <TextBox x:Name="ConsoleBox" Grid.Row="1" FontFamily="Consolas" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/FridaDesk.UI/Controls/ConsolePanel.axaml.cs
+++ b/src/FridaDesk.UI/Controls/ConsolePanel.axaml.cs
@@ -1,0 +1,47 @@
+// Autor: Pexe (Instagram: David.devloli)
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+
+namespace FridaDesk.UI.Controls;
+
+public partial class ConsolePanel : UserControl
+{
+    public static readonly StyledProperty<string> TextProperty =
+        AvaloniaProperty.Register<ConsolePanel, string>(nameof(Text), "");
+
+    public string Text
+    {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public ConsolePanel()
+    {
+        InitializeComponent();
+        this.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == TextProperty)
+                ConsoleBox.Text = Text;
+        };
+    }
+
+    private void OnCopy(object? sender, RoutedEventArgs e)
+    {
+        var tb = ConsoleBox;
+        TopLevel.GetTopLevel(this)?.Clipboard?.SetTextAsync(tb.Text ?? string.Empty);
+    }
+
+    private void OnClear(object? sender, RoutedEventArgs e)
+    {
+        Text = string.Empty;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/FridaDesk.UI/Controls/Severity.cs
+++ b/src/FridaDesk.UI/Controls/Severity.cs
@@ -1,0 +1,10 @@
+// Autor: Pexe (Instagram: David.devloli)
+namespace FridaDesk.UI.Controls;
+
+public enum Severity
+{
+    Success,
+    Warning,
+    Error,
+    Muted
+}

--- a/src/FridaDesk.UI/Controls/StatusBadge.axaml
+++ b/src/FridaDesk.UI/Controls/StatusBadge.axaml
@@ -1,0 +1,7 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FridaDesk.UI.Controls.StatusBadge">
+    <Border x:Name="PART_Border" Padding="4,2" CornerRadius="{StaticResource CornerRadiusS}">
+        <ContentPresenter HorizontalAlignment="Center"/>
+    </Border>
+</UserControl>

--- a/src/FridaDesk.UI/Controls/StatusBadge.axaml.cs
+++ b/src/FridaDesk.UI/Controls/StatusBadge.axaml.cs
@@ -1,0 +1,48 @@
+// Autor: Pexe (Instagram: David.devloli)
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+
+namespace FridaDesk.UI.Controls;
+
+public partial class StatusBadge : UserControl
+{
+    public static readonly StyledProperty<Severity> SeverityProperty =
+        AvaloniaProperty.Register<StatusBadge, Severity>(nameof(Severity), defaultValue: Severity.Muted);
+
+    public Severity Severity
+    {
+        get => GetValue(SeverityProperty);
+        set => SetValue(SeverityProperty, value);
+    }
+
+    public StatusBadge()
+    {
+        InitializeComponent();
+        this.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == SeverityProperty)
+                UpdateBackground(Severity);
+        };
+    }
+
+    private void UpdateBackground(Severity severity)
+    {
+        var border = this.FindControl<Border>("PART_Border");
+        var brush = severity switch
+        {
+            Severity.Success => (IBrush?)Application.Current?.FindResource("BrushOk"),
+            Severity.Warning => (IBrush?)Application.Current?.FindResource("BrushWarn"),
+            Severity.Error => (IBrush?)Application.Current?.FindResource("BrushError"),
+            _ => (IBrush?)Application.Current?.FindResource("BrushMuted")
+        };
+        border.Background = brush;
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/FridaDesk.UI/Controls/Toolbar.axaml
+++ b/src/FridaDesk.UI/Controls/Toolbar.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FridaDesk.UI.Controls.Toolbar">
+    <Border Background="{StaticResource SurfaceWindowBrush}" Padding="8">
+        <Grid ColumnDefinitions="Auto,*,Auto">
+            <TextBlock Text="{Binding Title, RelativeSource={RelativeSource AncestorType=UserControl}}" VerticalAlignment="Center" FontSize="{StaticResource FontSize20}"/>
+            <TextBox x:Name="SearchBox" Grid.Column="1" Margin="8,0" Watermark="Buscar"/>
+            <ContentPresenter Grid.Column="2" Content="{Binding Actions, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/FridaDesk.UI/Controls/Toolbar.axaml.cs
+++ b/src/FridaDesk.UI/Controls/Toolbar.axaml.cs
@@ -1,0 +1,37 @@
+// Autor: Pexe (Instagram: David.devloli)
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace FridaDesk.UI.Controls;
+
+public partial class Toolbar : UserControl
+{
+    public static readonly StyledProperty<string> TitleProperty =
+        AvaloniaProperty.Register<Toolbar, string>(nameof(Title), "");
+
+    public static readonly StyledProperty<object?> ActionsProperty =
+        AvaloniaProperty.Register<Toolbar, object?>(nameof(Actions));
+
+    public string Title
+    {
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public object? Actions
+    {
+        get => GetValue(ActionsProperty);
+        set => SetValue(ActionsProperty, value);
+    }
+
+    public Toolbar()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/FridaDesk.UI/FridaDesk.UI.csproj
+++ b/src/FridaDesk.UI/FridaDesk.UI.csproj
@@ -6,13 +6,14 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
-  </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Avalonia" Version="11.3.4" />
+      <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.4" />
+      <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.4" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <AvaloniaResource Include="Styles/Theme.xaml" />
-  </ItemGroup>
+    <ItemGroup>
+      <AvaloniaResource Include="Styles/Theme.xaml" />
+    </ItemGroup>
 
 </Project>

--- a/src/FridaDesk.UI/MainWindow.axaml
+++ b/src/FridaDesk.UI/MainWindow.axaml
@@ -1,0 +1,28 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="using:FridaDesk.UI.Controls"
+        xmlns:view="using:FridaDesk.UI.Views"
+        x:Class="FridaDesk.UI.MainWindow"
+        Title="FridaDesk">
+    <Window.KeyBindings>
+        <KeyBinding Gesture="Oem2" Command="{Binding FocusSearchCommand}"/>
+        <KeyBinding Gesture="Ctrl+R" Command="{Binding RefreshCommand}"/>
+        <KeyBinding Gesture="Ctrl+L" Command="{Binding ClearConsoleCommand}"/>
+    </Window.KeyBindings>
+    <Grid ColumnDefinitions="260,*" RowDefinitions="Auto,*,Auto">
+        <Border Grid.RowSpan="3" Width="260" Background="{StaticResource SurfaceCardBrush}" Padding="16">
+            <StackPanel Spacing="8">
+                <TextBlock Text="FridaDesk" FontSize="24" Margin="0,0,0,16"/>
+                <ToggleButton Content="Devices" IsChecked="True" Click="OnDevices"/>
+                <ToggleButton Content="Scripts" Click="OnScripts"/>
+                <ToggleButton Content="Histórico" Click="OnHistory"/>
+                <ToggleButton Content="Configurações" Click="OnSettings"/>
+            </StackPanel>
+        </Border>
+        <controls:Toolbar x:Name="TopBar" Grid.Column="1" Title="FridaDesk"/>
+        <ContentControl Grid.Column="1" Grid.Row="1" x:Name="ContentHost"/>
+        <Expander Grid.Column="1" Grid.Row="2" IsExpanded="True" Header="Console" MaxHeight="180">
+            <controls:ConsolePanel x:Name="Console" Height="180"/>
+        </Expander>
+    </Grid>
+</Window>

--- a/src/FridaDesk.UI/MainWindow.axaml.cs
+++ b/src/FridaDesk.UI/MainWindow.axaml.cs
@@ -1,0 +1,42 @@
+// Autor: Pexe (Instagram: David.devloli)
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using System.Windows.Input;
+using FridaDesk.UI.Views;
+
+namespace FridaDesk.UI;
+
+public partial class MainWindow : Window
+{
+    private readonly UserControl _devices = new DevicesView();
+    private readonly UserControl _scripts = new ScriptsView();
+    private readonly UserControl _history = new HistoryView();
+    private readonly UserControl _settings = new SettingsView();
+
+    public ICommand FocusSearchCommand { get; }
+    public ICommand RefreshCommand { get; }
+    public ICommand ClearConsoleCommand { get; }
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        DataContext = this;
+        ContentHost.Content = _devices;
+
+        FocusSearchCommand = new RelayCommand(() => TopBar.SearchBox?.Focus());
+        RefreshCommand = new RelayCommand(() => { });
+        ClearConsoleCommand = new RelayCommand(() => Console.Text = string.Empty);
+    }
+
+    private void OnDevices(object? sender, RoutedEventArgs e) => ContentHost.Content = _devices;
+    private void OnScripts(object? sender, RoutedEventArgs e) => ContentHost.Content = _scripts;
+    private void OnHistory(object? sender, RoutedEventArgs e) => ContentHost.Content = _history;
+    private void OnSettings(object? sender, RoutedEventArgs e) => ContentHost.Content = _settings;
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/FridaDesk.UI/RelayCommand.cs
+++ b/src/FridaDesk.UI/RelayCommand.cs
@@ -1,0 +1,25 @@
+// Autor: Pexe (Instagram: David.devloli)
+using System;
+using System.Windows.Input;
+
+namespace FridaDesk.UI;
+
+public class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute;
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+    public void Execute(object? parameter) => _execute();
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/src/FridaDesk.UI/Styles/Theme.xaml
+++ b/src/FridaDesk.UI/Styles/Theme.xaml
@@ -1,5 +1,6 @@
 <Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="using:FridaDesk.UI.Controls">
     <Styles.Resources>
         <!-- Colors -->
         <Color x:Key="PrimaryColor">#4F46E5</Color>
@@ -94,8 +95,22 @@
         <Setter Property="Foreground" Value="White"/>
     </Style>
 
-    <Style Selector="ScrollBar">
-        <Setter Property="Background" Value="{StaticResource SurfaceCardBrush}"/>
-        <Setter Property="Foreground" Value="{StaticResource PrimaryBrush}"/>
-    </Style>
+  <Style Selector="ScrollBar">
+          <Setter Property="Background" Value="{StaticResource SurfaceCardBrush}"/>
+          <Setter Property="Foreground" Value="{StaticResource PrimaryBrush}"/>
+      </Style>
+
+      <!-- Custom controls -->
+      <Style Selector="controls|StatusBadge">
+          <Setter Property="FontSize" Value="{StaticResource FontSize12}"/>
+          <Setter Property="Foreground" Value="White"/>
+      </Style>
+
+      <Style Selector="controls|Card">
+          <Setter Property="Margin" Value="4"/>
+      </Style>
+
+      <Style Selector="controls|Toolbar">
+          <Setter Property="Background" Value="{StaticResource SurfaceWindowBrush}"/>
+      </Style>
 </Styles>

--- a/src/FridaDesk.UI/ViewModels/DevicesViewModel.cs
+++ b/src/FridaDesk.UI/ViewModels/DevicesViewModel.cs
@@ -1,0 +1,32 @@
+// Autor: Pexe (Instagram: David.devloli)
+using System.Collections.ObjectModel;
+using FridaDesk.UI.Controls;
+
+namespace FridaDesk.UI.ViewModels;
+
+public class DevicesViewModel
+{
+    public ObservableCollection<DeviceItem> Devices { get; } = new()
+    {
+        new DeviceItem { Serial = "ABC123", Model = "Pixel 5", IsEmulator = false, Status = "Pronto" },
+        new DeviceItem { Serial = "EMUL01", Model = "Android Emulator", IsEmulator = true, Status = "Não Instalado" },
+        new DeviceItem { Serial = "IOS999", Model = "iPhone 12", IsEmulator = false, Status = "Erro" }
+    };
+}
+
+public class DeviceItem
+{
+    public string Serial { get; set; } = string.Empty;
+    public string Model { get; set; } = string.Empty;
+    public bool IsEmulator { get; set; }
+    public string Status { get; set; } = string.Empty;
+
+    public string EmulatorLabel => IsEmulator ? "Sim" : "Não";
+    public Severity EmulatorSeverity => IsEmulator ? Severity.Success : Severity.Muted;
+    public Severity StatusSeverity => Status switch
+    {
+        "Pronto" => Severity.Success,
+        "Erro" => Severity.Error,
+        _ => Severity.Muted
+    };
+}

--- a/src/FridaDesk.UI/ViewModels/HistoryViewModel.cs
+++ b/src/FridaDesk.UI/ViewModels/HistoryViewModel.cs
@@ -1,0 +1,34 @@
+// Autor: Pexe (Instagram: David.devloli)
+using System;
+using System.Collections.ObjectModel;
+using FridaDesk.UI.Controls;
+
+namespace FridaDesk.UI.ViewModels;
+
+public class HistoryViewModel
+{
+    public ObservableCollection<HistoryItem> Runs { get; } = new()
+    {
+        new HistoryItem { Date = DateTime.Now.AddMinutes(-5), Script = "Dump UI", Device = "Pixel 5", Status = "Ok" },
+        new HistoryItem { Date = DateTime.Now.AddMinutes(-30), Script = "Bypass SSL", Device = "Android Emulator", Status = "Erro" },
+        new HistoryItem { Date = DateTime.Now.AddHours(-2), Script = "Hook Touch", Device = "iPhone 12", Status = "Running" },
+        new HistoryItem { Date = DateTime.Now.AddHours(-5), Script = "Trace Calls", Device = "Pixel 5", Status = "Ok" },
+        new HistoryItem { Date = DateTime.Now.AddHours(-8), Script = "List Classes", Device = "Android Emulator", Status = "Ok" },
+        new HistoryItem { Date = DateTime.Now.AddDays(-1), Script = "Interno A", Device = "Pixel 5", Status = "Erro" }
+    };
+}
+
+public class HistoryItem
+{
+    public DateTime Date { get; set; }
+    public string Script { get; set; } = string.Empty;
+    public string Device { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public Severity StatusSeverity => Status switch
+    {
+        "Ok" => Severity.Success,
+        "Erro" => Severity.Error,
+        "Running" => Severity.Warning,
+        _ => Severity.Muted
+    };
+}

--- a/src/FridaDesk.UI/ViewModels/ScriptsViewModel.cs
+++ b/src/FridaDesk.UI/ViewModels/ScriptsViewModel.cs
@@ -1,0 +1,29 @@
+// Autor: Pexe (Instagram: David.devloli)
+using System.Collections.ObjectModel;
+
+namespace FridaDesk.UI.ViewModels;
+
+public class ScriptsViewModel
+{
+    public ObservableCollection<ScriptItem> Scripts { get; } = new()
+    {
+        new ScriptItem { Title="Dump UI", Author="User1", Source="Codeshare", Tags=new[]{"ui","android"} },
+        new ScriptItem { Title="Bypass SSL", Author="User2", Source="Codeshare", Tags=new[]{"network","android"} },
+        new ScriptItem { Title="Hook Touch", Author="User3", Source="Codeshare", Tags=new[]{"input","android"} },
+        new ScriptItem { Title="Trace Calls", Author="User4", Source="Codeshare", Tags=new[]{"trace","ios"} },
+        new ScriptItem { Title="List Classes", Author="User5", Source="Codeshare", Tags=new[]{"introspect","ios"} },
+        new ScriptItem { Title="Interno A", Author="Equipe", Source="Interno", Tags=new[]{"interno","android"} },
+        new ScriptItem { Title="Interno B", Author="Equipe", Source="Interno", Tags=new[]{"interno","ios"} },
+        new ScriptItem { Title="Interno C", Author="Equipe", Source="Interno", Tags=new[]{"interno","android"} },
+        new ScriptItem { Title="Interno D", Author="Equipe", Source="Interno", Tags=new[]{"interno","ios"} },
+        new ScriptItem { Title="Interno E", Author="Equipe", Source="Interno", Tags=new[]{"interno","android"} }
+    };
+}
+
+public class ScriptItem
+{
+    public string Title { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string Source { get; set; } = string.Empty;
+    public string[] Tags { get; set; } = System.Array.Empty<string>();
+}

--- a/src/FridaDesk.UI/ViewModels/SettingsViewModel.cs
+++ b/src/FridaDesk.UI/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,14 @@
+// Autor: Pexe (Instagram: David.devloli)
+using System.Collections.ObjectModel;
+
+namespace FridaDesk.UI.ViewModels;
+
+public class SettingsViewModel
+{
+    public string AdbPath { get; set; } = "/usr/bin/adb";
+    public string FridaPath { get; set; } = "/usr/bin/frida";
+    public ObservableCollection<string> Themes { get; } = new() { "Dark", "Light", "System" };
+    public string SelectedTheme { get; set; } = "System";
+    public bool ShowElevatedTargets { get; set; } = true;
+    public bool EnableJailbreakFeature { get; set; } = false;
+}

--- a/src/FridaDesk.UI/Views/DevicesView.axaml
+++ b/src/FridaDesk.UI/Views/DevicesView.axaml
@@ -1,0 +1,35 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="using:FridaDesk.UI.Controls"
+             x:Class="FridaDesk.UI.Views.DevicesView">
+    <DataGrid ItemsSource="{Binding Devices}" AutoGenerateColumns="False" HeadersVisibility="All">
+        <DataGrid.Columns>
+            <DataGridTextColumn Header="Serial" Binding="{Binding Serial}"/>
+            <DataGridTextColumn Header="Modelo" Binding="{Binding Model}"/>
+            <DataGridTemplateColumn Header="Emulador">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <controls:StatusBadge Content="{Binding EmulatorLabel}" Severity="{Binding EmulatorSeverity}"/>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="Status">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <controls:StatusBadge Content="{Binding Status}" Severity="{Binding StatusSeverity}"/>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTemplateColumn Header="Ações">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <Button Content="Detalhes" IsEnabled="False"/>
+                            <Button Content="Conectar" IsEnabled="False"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/src/FridaDesk.UI/Views/DevicesView.axaml.cs
+++ b/src/FridaDesk.UI/Views/DevicesView.axaml.cs
@@ -1,0 +1,20 @@
+// Autor: Pexe (Instagram: David.devloli)
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using FridaDesk.UI.ViewModels;
+
+namespace FridaDesk.UI.Views;
+
+public partial class DevicesView : UserControl
+{
+    public DevicesView()
+    {
+        InitializeComponent();
+        DataContext = new DevicesViewModel();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/FridaDesk.UI/Views/HistoryView.axaml
+++ b/src/FridaDesk.UI/Views/HistoryView.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="using:FridaDesk.UI.Controls"
+             x:Class="FridaDesk.UI.Views.HistoryView">
+    <DataGrid ItemsSource="{Binding Runs}" AutoGenerateColumns="False" HeadersVisibility="All">
+        <DataGrid.Columns>
+            <DataGridTextColumn Header="Data" Binding="{Binding Date}"/>
+            <DataGridTextColumn Header="Script" Binding="{Binding Script}"/>
+            <DataGridTextColumn Header="Device" Binding="{Binding Device}"/>
+            <DataGridTemplateColumn Header="Status">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <controls:StatusBadge Content="{Binding Status}" Severity="{Binding StatusSeverity}"/>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/src/FridaDesk.UI/Views/HistoryView.axaml.cs
+++ b/src/FridaDesk.UI/Views/HistoryView.axaml.cs
@@ -1,0 +1,20 @@
+// Autor: Pexe (Instagram: David.devloli)
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using FridaDesk.UI.ViewModels;
+
+namespace FridaDesk.UI.Views;
+
+public partial class HistoryView : UserControl
+{
+    public HistoryView()
+    {
+        InitializeComponent();
+        DataContext = new HistoryViewModel();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/FridaDesk.UI/Views/ScriptsView.axaml
+++ b/src/FridaDesk.UI/Views/ScriptsView.axaml
@@ -1,0 +1,32 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="using:FridaDesk.UI.Controls"
+             x:Class="FridaDesk.UI.Views.ScriptsView">
+    <ScrollViewer>
+        <ItemsControl ItemsSource="{Binding Scripts}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <controls:Card Margin="8">
+                        <controls:Card.Header>
+                            <TextBlock Text="{Binding Title}" FontSize="{StaticResource FontSize16}"/>
+                        </controls:Card.Header>
+                        <StackPanel Spacing="4">
+                            <TextBlock Text="{Binding Author} ({Binding Source})"/>
+                            <ItemsControl ItemsSource="{Binding Tags}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <controls:StatusBadge Content="{Binding}" Severity="Muted" Margin="0,0,4,4"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <Button Content="Executar" IsEnabled="False"/>
+                        </StackPanel>
+                    </controls:Card>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </ScrollViewer>
+</UserControl>

--- a/src/FridaDesk.UI/Views/ScriptsView.axaml.cs
+++ b/src/FridaDesk.UI/Views/ScriptsView.axaml.cs
@@ -1,0 +1,20 @@
+// Autor: Pexe (Instagram: David.devloli)
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using FridaDesk.UI.ViewModels;
+
+namespace FridaDesk.UI.Views;
+
+public partial class ScriptsView : UserControl
+{
+    public ScriptsView()
+    {
+        InitializeComponent();
+        DataContext = new ScriptsViewModel();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/FridaDesk.UI/Views/SettingsView.axaml
+++ b/src/FridaDesk.UI/Views/SettingsView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="FridaDesk.UI.Views.SettingsView">
+    <ScrollViewer>
+        <StackPanel Spacing="8" Margin="16">
+            <TextBlock Text="ADB Path"/>
+            <TextBox Text="{Binding AdbPath}"/>
+            <TextBlock Text="Frida Path" Margin="0,8,0,0"/>
+            <TextBox Text="{Binding FridaPath}"/>
+            <TextBlock Text="Tema" Margin="0,8,0,0"/>
+            <ComboBox ItemsSource="{Binding Themes}" SelectedItem="{Binding SelectedTheme}"/>
+            <ToggleSwitch Content="Mostrar alvos elevados" IsChecked="{Binding ShowElevatedTargets}" Margin="0,8,0,0"/>
+            <ToggleSwitch Content="Habilitar recurso de jailbreak" IsChecked="{Binding EnableJailbreakFeature}" IsEnabled="False"/>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/FridaDesk.UI/Views/SettingsView.axaml.cs
+++ b/src/FridaDesk.UI/Views/SettingsView.axaml.cs
@@ -1,0 +1,20 @@
+// Autor: Pexe (Instagram: David.devloli)
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using FridaDesk.UI.ViewModels;
+
+namespace FridaDesk.UI.Views;
+
+public partial class SettingsView : UserControl
+{
+    public SettingsView()
+    {
+        InitializeComponent();
+        DataContext = new SettingsViewModel();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Resumo
- Implementa controles reutilizáveis (StatusBadge, Toolbar, Card e ConsolePanel) com estilos no Theme.xaml
- Cria MainWindow com sidebar, barra superior e ConsolePanel, incluindo atalhos de teclado
- Adiciona views e viewmodels mockadas para Devices, Scripts, History e Settings com dados de exemplo

## Testes
- `dotnet build src/FridaDesk.UI/FridaDesk.UI.csproj`


------
https://chatgpt.com/codex/tasks/task_b_68aa7ddd45948322a33b7f9daaacf9ef