### PR TITLE
chore: padroniza finais de linha para LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Resumo
- adiciona `.gitattributes` para forçar uso de LF



## Summary by CodeRabbit

- **Chores**
  - Padronização de finais de linha (LF) via configuração global no .gitattributes.
  - Normalização automática de arquivos de texto em commits e checkouts.
  - Sem impacto em funcionalidades ou API pública.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->