### PR TITLE
Corrige erro de módulo do Electron ao iniciar o app

### DIFF
--- a/main.cjs
+++ b/main.cjs
@@ -1,8 +1,5 @@
-import { app, BrowserWindow } from 'electron';
-import { join } from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = join(fileURLToPath(import.meta.url), '..');
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -13,7 +10,7 @@ function createWindow() {
     },
   });
 
-  win.loadFile(join(__dirname, 'dist/index.html'));
+  win.loadFile(path.join(__dirname, 'dist/index.html'));
 }
 
 app.whenReady().then(() => {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Pexe (instagram: @David.devloli)",
   "license": "MIT",
   "type": "module",
-  "main": "main.js",
+  "main": "main.cjs",
   "scripts": {
     "start": "npm run electron:start",
     "dev": "vite",
@@ -42,7 +42,7 @@
     "productName": "FridaDesk",
     "files": [
       "dist/**/*",
-      "main.js"
+      "main.cjs"
     ],
     "win": {
       "target": "nsis"


### PR DESCRIPTION
## Resumo
- converte `main.js` para `main.cjs` em CommonJS
- ajusta `package.json` para apontar para `main.cjs`

## Testes
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68ab7c71ebb083229b39a59dccfb66a7