### PR TITLE
docs: definir contratos de IPC e API local

### DIFF
--- a/docs/api-local.md
+++ b/docs/api-local.md
@@ -1,0 +1,34 @@
+# API Local para Mobile Companion
+
+API HTTP para exposição de dados básicos ao app companion.
+
+## 1. Endpoints
+
+- `GET /api/health` → `{ ok: true, timestamp }`.
+- `GET /api/executions?limit=N` → retorna as últimas N execuções.
+
+## 2. Segurança
+
+- Bind em `127.0.0.1` por padrão.
+- Opção de token de acesso.
+- CORS desativado.
+
+## 3. Rate Limiting
+
+- Limite básico de requisições por minuto.
+
+## 4. Observabilidade
+
+- Logs de requests e contadores simples.
+
+## 5. Evolução
+
+- Planejado suporte a streaming (SSE/WebSocket) para logs ao vivo em fase futura.
+
+## 6. Configuração
+
+- Escopo e porta configuráveis via `config`.
+
+---
+
+Autor: Pexe (instagram: @David.devloli)

--- a/docs/contratos-ipc.md
+++ b/docs/contratos-ipc.md
@@ -1,0 +1,37 @@
+# Contratos de IPC (Front ↔ Main)
+
+Documento acordado entre times de front e back para padronizar a comunicação via IPC.
+
+## 1. Canais
+
+- **devices:list** → lista de dispositivos.
+- **adb:connect** / **adb:tcpip** / **adb:install**.
+- **frida:processes** / **frida:runScript** / **frida:stop**.
+- **scripts:list** / **scripts:import** / **scripts:delete**.
+- **history:list** / **history:export**.
+- **config:get** / **config:set**.
+- Eventos: **exec:log** (stream de mensagens) e **exec:event** (started/stopped/error).
+
+## 2. Payloads
+
+Todos os payloads usam JSON com campos:
+
+- Strings, números e arrays conforme a função.
+- Campos obrigatórios explicitados, demais opcionais.
+- Exemplo `devices:list`: resposta `{ ok: true, devices: [{ id, name }] }`.
+
+## 3. Erros
+
+Formato unificado: `{ ok: false, error: "mensagem" }` com mensagens curtas.
+
+## 4. Timeouts e Retry
+
+O front aplica timeout de 10 s com feedback ao usuário e pode tentar novamente.
+
+## 5. Versionamento
+
+`config:get` inclui campo `appVersion` para sincronizar mudanças de contrato.
+
+---
+
+Autor: Pexe (instagram: @David.devloli)


### PR DESCRIPTION
## Resumo
- documenta contratos de IPC entre front e main
- descreve API local para futuro companion mobile

## Testes
- `npm test`
- `npm run lint`
