### PR TITLE
docs: documentar núcleo do back-end e contratos IPC

### DIFF
--- a/docs/contratos-ipc.md
+++ b/docs/contratos-ipc.md
@@ -2,33 +2,53 @@
 
 Documento acordado entre times de front e back para padronizar a comunicação via IPC.
 
-## 1. Canais
+## 1. Canais e Payloads
 
-- **devices:list** → lista de dispositivos.
-- **adb:connect** / **adb:tcpip** / **adb:install**.
-- **frida:processes** / **frida:runScript** / **frida:stop**.
-- **scripts:list** / **scripts:import** / **scripts:delete**.
-- **history:list** / **history:export**.
-- **config:get** / **config:set**.
-- Eventos: **exec:log** (stream de mensagens) e **exec:event** (started/stopped/error).
+| Canal | Requisição | Resposta | Erros (códigos) | Timeout |
+|------|------------|----------|-----------------|---------|
+| `devices:list` | `-` | `{ ok: true, devices: [{ id, name }] }` | `E_ADB_OFFLINE` | 10 s |
+| `adb:connect` | `{ id }` | `{ ok: true }` | `E_DEVICE_NOT_FOUND`, `E_ADB_ERROR` | 10 s |
+| `adb:install` | `{ id, apkPath }` | `{ ok: true }` | `E_INSTALL_FAILED` | 30 s |
+| `frida:processes` | `{ deviceId? }` | `{ ok: true, processes: [{ pid, name }] }` | `E_FRIDA_ERROR` | 10 s |
+| `frida:runScript` | `{ deviceId, target, script }` | `{ ok: true, execId }` | `E_PROCESS_NOT_FOUND`, `E_SCRIPT_ERROR` | 10 s |
+| `frida:stop` | `{ execId }` | `{ ok: true }` | `E_EXEC_NOT_FOUND` | 10 s |
+| `scripts:list` | `-` | `{ ok: true, scripts: [...] }` | `E_IO` | 5 s |
+| `scripts:import` | `{ name, source, tags[] }` | `{ ok: true, id }` | `E_VALIDATION`, `E_IO` | 5 s |
+| `scripts:delete` | `{ id }` | `{ ok: true }` | `E_SCRIPT_NOT_FOUND` | 5 s |
+| `history:list` | `{ limit }` | `{ ok: true, executions: [...] }` | `E_IO` | 5 s |
+| `history:export` | `{ format, path }` | `{ ok: true, file }` | `E_IO`, `E_EXPORT_FAILED` | 30 s |
+| `config:get` | `{ key? }` | `{ ok: true, value | config }` | `E_CONFIG_NOT_FOUND` | 5 s |
+| `config:set` | `{ key, value }` | `{ ok: true }` | `E_CONFIG_INVALID` | 5 s |
 
-## 2. Payloads
+### Eventos
 
-Todos os payloads usam JSON com campos:
+| Evento | Payload |
+|--------|---------|
+| `exec:log` | `{ execId, message }` |
+| `exec:event` | `{ execId, type: 'started' | 'stopped' | 'error', data? }` |
 
-- Strings, números e arrays conforme a função.
-- Campos obrigatórios explicitados, demais opcionais.
-- Exemplo `devices:list`: resposta `{ ok: true, devices: [{ id, name }] }`.
+## 2. Códigos de Erro
 
-## 3. Erros
+- `E_ADB_OFFLINE`: daemon ADB não respondeu.
+- `E_DEVICE_NOT_FOUND`: dispositivo não encontrado.
+- `E_ADB_ERROR`: erro genérico do ADB.
+- `E_INSTALL_FAILED`: falha na instalação do APK.
+- `E_FRIDA_ERROR`: operação Frida falhou.
+- `E_PROCESS_NOT_FOUND`: processo alvo não encontrado.
+- `E_SCRIPT_ERROR`: script inválido ou falha de execução.
+- `E_EXEC_NOT_FOUND`: execução não encontrada.
+- `E_IO`: erro de leitura ou escrita.
+- `E_VALIDATION`: dados de entrada inválidos.
+- `E_SCRIPT_NOT_FOUND`: script não encontrado.
+- `E_EXPORT_FAILED`: falha ao exportar histórico.
+- `E_CONFIG_NOT_FOUND`: chave de configuração inexistente.
+- `E_CONFIG_INVALID`: valor de configuração inválido.
 
-Formato unificado: `{ ok: false, error: "mensagem" }` com mensagens curtas.
+## 3. Timeouts e Retry
 
-## 4. Timeouts e Retry
+O front aplica timeout padrão de 10 s e tenta novamente em falhas transitórias. Operações de instalação e exportação usam 30 s.
 
-O front aplica timeout de 10 s com feedback ao usuário e pode tentar novamente.
-
-## 5. Versionamento
+## 4. Versionamento
 
 `config:get` inclui campo `appVersion` para sincronizar mudanças de contrato.
 

--- a/docs/nucleo-backend.md
+++ b/docs/nucleo-backend.md
@@ -1,0 +1,57 @@
+# Núcleo do Back-end (Electron Main)
+
+Documento descrevendo os processos e serviços que orquestram o núcleo do aplicativo.
+
+## 1. Processo Principal
+
+- **Ciclo de vida**: inicia ao `app.whenReady`, cria a janela principal e encerra quando todas as janelas fecham.
+- **Janela**: instancia `BrowserWindow` com contexto isolado e uso mínimo de permissões.
+- **Preload**: carrega script com `contextBridge` para expor APIs seguras de IPC ao renderer.
+
+## 2. Módulos Isolados
+
+### 2.1 ADB Service
+
+- Lista dispositivos conectados.
+- Conecta via TCP/IP (`adb tcpip`, `adb connect`).
+- Instala APKs em dispositivos selecionados.
+- Operações enfileiradas com _backoff_ para lidar com falhas do daemon ADB.
+
+### 2.2 Frida Service (frida-node)
+
+- Lista processos disponíveis no dispositivo.
+- `spawn/attach` em alvos definidos.
+- Injeta scripts e roteia mensagens/erros para o renderer.
+- Encerra sessões sob demanda e reconecta em `session.detached`.
+
+### 2.3 Scripts Service
+
+- CRUD local de scripts: nome, tags, origem, código‑fonte e favorito.
+- Armazena metadados para busca rápida.
+
+### 2.4 Execuções/Logs Service
+
+- Registra início/fim das execuções e mantém log em JSONL.
+- Stream em tempo real para o renderer via IPC.
+- Exporta logs em JSONL ou TXT.
+- Possui _circuit‑breaker_ para evitar floods de log.
+
+### 2.5 Config Service
+
+- Persiste tema, cores, caminhos de arquivos e porta da API local.
+- Expõe métodos `get/set` via IPC.
+
+### 2.6 Plugins Loader
+
+- Carrega extensões opcionais (CodeShare, métricas etc.).
+- Isola cada plugin em sandbox para evitar conflitos.
+
+## 3. Tolerância a Falhas
+
+- Fila com _backoff_ para comandos ADB.
+- Reconexão automática de sessões Frida ao receber `session.detached`.
+- _Circuit‑breaker_ para fluxos de log excessivos.
+
+---
+
+Autor: Pexe (instagram: @David.devloli)


### PR DESCRIPTION
## Resumo
- descrever ciclo de vida do processo principal e serviços isolados
- detalhar tolerância a falhas e carregamento de plugins
- padronizar contratos IPC com payloads, timeouts e códigos de erro
