### PR TITLE
Corrige build do Vite no ambiente Electron

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,20 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: './',
   plugins: [react()],
+  // Externaliza módulos nativos do Node e adbkit para o ambiente Electron
+  build: {
+    rollupOptions: {
+      external: [
+        'adbkit',
+        'assert',
+        'child_process',
+        'crypto',
+        'events',
+        'fs',
+        'net',
+        'path',
+        'stream',
+      ],
+    },
+  },
 });


### PR DESCRIPTION
## Resumo
- externaliza adbkit e módulos nativos do Node no build do Vite para compatibilidade com Electron

## Testes
- `npm run build`
- `npm test`

Autor: Pexe (instagram: @David.devloli)

------
https://chatgpt.com/codex/tasks/task_b_68ab8cc750f48322ac978bc2da3ef877