### PR TITLE
Corrige uso de módulos nativos no renderer

### DIFF
--- a/src/adbService.js
+++ b/src/adbService.js
@@ -1,5 +1,9 @@
 // Autor: Pexe (instagram: @David.devloli)
-import adb from 'adbkit';
+// Garante uso do adbkit em ambientes diferentes
+const adb =
+  typeof window !== 'undefined' && window.require
+    ? window.require('adbkit')
+    : (await import('adbkit')).default;
 
 const client = adb.createClient();
 

--- a/src/db.js
+++ b/src/db.js
@@ -1,6 +1,13 @@
 import initSqlJs from 'sql.js';
-import fs from 'fs';
-import path from 'path';
+import { createRequire } from 'module';
+
+// Garante acesso aos módulos nativos tanto no Electron quanto nos testes
+const require =
+  typeof window !== 'undefined' && window.require
+    ? window.require
+    : createRequire(import.meta.url);
+const fs = require('fs');
+const path = require('path');
 
 /**
  * Gerenciador de banco de dados SQLite utilizando sql.js.


### PR DESCRIPTION
## Resumo
- ajusta importações de `fs` e `path` para funcionarem no Electron e nos testes
- carrega `adbkit` conforme o ambiente para evitar tela em branco
