### PR TITLE
fix: tratar ausência do adbkit

### DIFF
--- a/src/adbService.js
+++ b/src/adbService.js
@@ -1,15 +1,19 @@
 // Autor: Pexe (instagram: @David.devloli)
 // Garante uso do adbkit em ambientes diferentes sem `top-level await`
-const adbPromise =
+const adbPromise = (
   typeof window !== 'undefined' && window.require
-    ? Promise.resolve(window.require('adbkit'))
-    : import('adbkit').then((m) => m.default);
+    ? Promise.resolve().then(() => window.require('adbkit'))
+    : import('adbkit').then((m) => m.default)
+).catch((err) => {
+  console.warn('Falha ao carregar adbkit:', err);
+  return null;
+});
 
 let clientPromise;
 
 function getClient() {
   if (!clientPromise) {
-    clientPromise = adbPromise.then((adb) => adb.createClient());
+    clientPromise = adbPromise.then((adb) => (adb ? adb.createClient() : null));
   }
   return clientPromise;
 }
@@ -17,6 +21,9 @@ function getClient() {
 export async function listDevices() {
   const client = await getClient();
   const adb = await adbPromise;
+  if (!client || !adb) {
+    return [];
+  }
   try {
     const devices = await client.listDevices();
     return Promise.all(
@@ -41,11 +48,13 @@ export async function listDevices() {
 
 export async function connectAdb(host, port = 5555) {
   const client = await getClient();
+  if (!client) throw new Error('adbkit não disponível');
   return client.connect(host, port);
 }
 
 export async function autoConnectEmulators(start = 5555, end = 5585) {
   const client = await getClient();
+  if (!client) return;
   for (let port = start; port <= end; port += 2) {
     try {
       await client.connect('127.0.0.1', port);
@@ -57,23 +66,27 @@ export async function autoConnectEmulators(start = 5555, end = 5585) {
 
 export async function connectTcpip(id, host, port = 5555) {
   const client = await getClient();
+  if (!client) throw new Error('adbkit não disponível');
   await client.tcpip(id, port);
   return client.connect(host, port);
 }
 
 export async function installApk(id, apkPath) {
   const client = await getClient();
+  if (!client) throw new Error('adbkit não disponível');
   return client.install(id, apkPath);
 }
 
 export async function startLogcat(id) {
   const client = await getClient();
+  if (!client) throw new Error('adbkit não disponível');
   return client.openLogcat(id);
 }
 
 export async function healthCheck(id) {
   const client = await getClient();
   const adb = await adbPromise;
+  if (!client || !adb) return false;
   const stream = await client.shell(id, 'echo OK');
   const output = (await adb.util.readAll(stream)).toString().trim();
   return output === 'OK';

--- a/tests/adbServiceNoAdb.test.js
+++ b/tests/adbServiceNoAdb.test.js
@@ -1,0 +1,16 @@
+import { jest } from '@jest/globals';
+
+let listDevices;
+
+beforeAll(async () => {
+  jest.resetModules();
+  await jest.unstable_mockModule('adbkit', () => {
+    throw new Error('módulo ausente');
+  });
+  ({ listDevices } = await import('../src/adbService.js'));
+});
+
+test('listDevices retorna vazio quando adbkit não está disponível', async () => {
+  const devices = await listDevices();
+  expect(devices).toEqual([]);
+});


### PR DESCRIPTION
## Resumo
- trata erro ao carregar o `adbkit` e evita falhas quando o módulo não está presente
- adiciona teste para garantir retorno vazio sem o `adbkit`

