### PR TITLE
feat: catálogo local de scripts com importação e favoritos

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export function soma(a, b) {
 }
 
 export { Database } from './db.js';
+export { ScriptsService } from './scriptsService.js';
 export {
   listDevices,
   connectAdb,

--- a/src/scriptsService.js
+++ b/src/scriptsService.js
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+/**
+ * Serviço para gerenciamento de scripts locais e do CodeShare.
+ * Mantido por Pexe (instagram: David.devloli)
+ */
+export class ScriptsService {
+  constructor(db) {
+    this.db = db;
+  }
+
+  checksum(source) {
+    return crypto.createHash('sha256').update(source).digest('hex');
+  }
+
+  async add({ name, tags = [], source, origin, favorite = false }) {
+    const checksum = this.checksum(source);
+    return this.db.insertScript({
+      name,
+      tags,
+      source,
+      origin,
+      favorite,
+      checksum,
+    });
+  }
+
+  async importFromFile(filePath, opts = {}) {
+    const source = fs.readFileSync(filePath, 'utf8');
+    const name = opts.name || path.basename(filePath);
+    return this.add({
+      name,
+      tags: opts.tags || [],
+      source,
+      origin: `file:${filePath}`,
+      favorite: opts.favorite,
+    });
+  }
+
+  async importFromUrl(url, opts = {}) {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Falha ao baixar script');
+    const source = await res.text();
+    const name = opts.name || path.basename(new URL(url).pathname) || 'script';
+    return this.add({
+      name,
+      tags: opts.tags || [],
+      source,
+      origin: `url:${url}`,
+      favorite: opts.favorite,
+    });
+  }
+
+  async importFromCodeShare(identifier, opts = {}) {
+    const rawUrl = `https://codeshare.frida.re/@${identifier}?format=raw`;
+    const pageUrl = `https://codeshare.frida.re/@${identifier}`;
+    const res = await fetch(rawUrl);
+    if (!res.ok) throw new Error('Falha ao baixar script do CodeShare');
+    const source = await res.text();
+    let name = opts.name || identifier;
+    let tags = opts.tags || [];
+    try {
+      const resPage = await fetch(pageUrl);
+      if (resPage.ok) {
+        const html = await resPage.text();
+        const titleMatch = html.match(/<h1[^>]*>([^<]+)<\/h1>/i);
+        if (titleMatch) name = titleMatch[1].trim();
+        const tagMatch = html.match(/data-tags="([^"]*)"/i);
+        if (tagMatch)
+          tags = tagMatch[1]
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean);
+      }
+    } catch (e) {
+      // ignora falhas ao obter metadados
+    }
+    return this.add({
+      name,
+      tags,
+      source,
+      origin: `codeshare:${identifier}`,
+      favorite: opts.favorite,
+    });
+  }
+
+  list() {
+    return this.db.listScripts();
+  }
+
+  setFavorite(id, favorite) {
+    return this.db.updateScriptFavorite(id, favorite);
+  }
+
+  get(id) {
+    return this.db.getScriptById(id);
+  }
+}

--- a/tests/scriptsService.test.js
+++ b/tests/scriptsService.test.js
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import http from 'http';
+import { Database } from '../src/db.js';
+import { ScriptsService } from '../src/scriptsService.js';
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fridadesk-test-'));
+}
+
+test('importa script de arquivo com metadados', async () => {
+  const dir = tempDir();
+  const dbPath = path.join(dir, 'db.sqlite');
+  const db = new Database({ dbPath });
+  await db.init();
+  const service = new ScriptsService(db);
+  const scriptPath = path.join(dir, 'teste.js');
+  fs.writeFileSync(scriptPath, 'console.log("oi")');
+  const id = await service.importFromFile(scriptPath, { tags: ['local'] });
+  const script = db.getScriptById(id);
+  expect(script.name).toBe('teste.js');
+  expect(script.origin).toBe(`file:${scriptPath}`);
+  expect(script.tags).toEqual(['local']);
+  expect(script.favorite).toBe(0);
+  expect(script.checksum).toBe(service.checksum('console.log("oi")'));
+});
+
+test('importa script via URL e marca favorito', async () => {
+  const dir = tempDir();
+  const dbPath = path.join(dir, 'db.sqlite');
+  const db = new Database({ dbPath });
+  await db.init();
+  const service = new ScriptsService(db);
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('console.log("net")');
+  });
+  await new Promise((resolve) => server.listen(0, resolve));
+  const { port } = server.address();
+  const url = `http://localhost:${port}/script.js`;
+  const id = await service.importFromUrl(url, {
+    favorite: true,
+    tags: ['remote'],
+  });
+  server.close();
+  const script = db.getScriptById(id);
+  expect(script.origin).toBe(`url:${url}`);
+  expect(script.favorite).toBe(1);
+  expect(script.tags).toEqual(['remote']);
+});


### PR DESCRIPTION
## Resumo
- ampliar tabela de scripts com origem, favorito e checksum
- adicionar serviço de scripts com importação de arquivo, URL e CodeShare
- incluir testes para catálogo local de scripts
