### PR TITLE
feat: implementar captura de rede com Frida

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Criar uma plataforma de desenvolvimento segura e colaborativa para integrar ferr
 - `npm run lint` – roda ESLint e Prettier
 - `npm test` – executa testes com Jest
 
+## Captura de Rede
+
+O projeto inclui uma DSL de captura HTTP/HTTPS que permite registrar tráfego diretamente no processo do app usando Frida. O script `src/scripts/httpCapture.js` intercepta requisições em OkHttp, HttpUrlConnection e nas funções nativas `SSL_read`/`SSL_write`, enviando eventos padronizados para o agregador `NetworkCapture` que gera métricas e exporta em JSONL ou HAR.
+
 ## Branching
 
 - `main`: código estável

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export function soma(a, b) {
 
 export { Database } from './db.js';
 export { ScriptsService } from './scriptsService.js';
+export { NetworkCapture } from './networkCapture.js';
 export {
   listDevices,
   connectAdb,

--- a/src/networkCapture.js
+++ b/src/networkCapture.js
@@ -1,0 +1,145 @@
+// DSL e agregador para eventos de rede HTTP/HTTPS
+// Mantido por Pexe (instagram: David.devloli)
+
+import { EventEmitter } from 'events';
+
+/**
+ * @typedef {Object} NetEvent
+ * @property {string} type - 'http.request' ou 'http.response'
+ * @property {string} execId - identificador único da requisição
+ * @property {number} ts - timestamp em ms
+ * @property {number} pid
+ * @property {number} tid
+ * @property {'java'|'native'} api
+ * @property {string} [lib] - biblioteca de origem (OkHttp, libssl.so...)
+ * @property {string} [url]
+ * @property {string} [method]
+ * @property {Object} [headers]
+ * @property {string} [body]
+ * @property {number} [status]
+ * @property {number} [latencyMs]
+ * @property {'out'|'in'} direction
+ */
+
+/**
+ * Classe responsável por receber eventos via Frida e calcular métricas.
+ * Opcionalmente realiza mascaramento de dados sensíveis e corta payloads.
+ */
+export class NetworkCapture extends EventEmitter {
+  constructor({ maskKeys = [], payloadLimit = 0 } = {}) {
+    super();
+    this.events = [];
+    this.maskKeys = maskKeys.map((k) => k.toLowerCase());
+    this.payloadLimit = payloadLimit;
+    this.pending = new Map(); // execId -> ts
+    this.latencies = [];
+    this.errors = 0;
+  }
+
+  /**
+   * Adiciona evento bruto vindo do script Frida.
+   * @param {NetEvent} evt
+   */
+  addEvent(evt) {
+    const safe = this._sanitize(evt);
+    this.events.push(safe);
+    if (safe.type === 'http.request') {
+      this.pending.set(safe.execId, safe.ts);
+    } else if (safe.type === 'http.response') {
+      const start = this.pending.get(safe.execId);
+      if (start !== undefined) {
+        const latency = safe.ts - start;
+        safe.latencyMs = latency;
+        this.latencies.push(latency);
+        this.pending.delete(safe.execId);
+      }
+      if (typeof safe.status === 'number' && safe.status >= 400) {
+        this.errors += 1;
+      }
+    }
+    this.emit('event', safe);
+  }
+
+  /**
+   * Retorna métricas agregadas das requisições capturadas.
+   */
+  getMetrics() {
+    const total = this.latencies.length;
+    const avg = total ? this.latencies.reduce((a, b) => a + b, 0) / total : 0;
+    const sorted = [...this.latencies].sort((a, b) => a - b);
+    const p95 = total
+      ? sorted[
+          Math.min(sorted.length - 1, Math.floor(0.95 * (sorted.length - 1)))
+        ]
+      : 0;
+    const errorRate = total ? this.errors / total : 0;
+    return { total, avg, p95, errorRate };
+  }
+
+  /**
+   * Converte eventos para linhas JSON (JSONL).
+   */
+  toJSONL() {
+    return this.events.map((e) => JSON.stringify(e)).join('\n');
+  }
+
+  /**
+   * Converte eventos para formato HAR 1.2 simples.
+   */
+  toHAR() {
+    const entries = [];
+    for (const evt of this.events) {
+      if (evt.type === 'http.request') {
+        const entry = {
+          startedDateTime: new Date(evt.ts).toISOString(),
+          time: 0,
+          request: {
+            method: evt.method || '',
+            url: evt.url || '',
+            headers: this._headersArray(evt.headers),
+            bodySize: evt.body ? evt.body.length : 0,
+            postData: evt.body ? { text: evt.body } : undefined,
+          },
+          response: {},
+        };
+        entries.push(entry);
+        evt.__har = entry;
+      } else if (evt.type === 'http.response' && evt.__har) {
+        evt.__har.time = evt.latencyMs || 0;
+        evt.__har.response = {
+          status: evt.status || 0,
+          headers: this._headersArray(evt.headers),
+          content: evt.body ? { text: evt.body } : {},
+        };
+      }
+    }
+    return { log: { version: '1.2', creator: { name: 'FridaDesk' }, entries } };
+  }
+
+  _headersArray(obj = {}) {
+    return Object.entries(obj).map(([name, value]) => ({ name, value }));
+  }
+
+  _sanitize(evt) {
+    const clone = JSON.parse(JSON.stringify(evt));
+    if (clone.headers) {
+      for (const k of Object.keys(clone.headers)) {
+        if (this.maskKeys.includes(k.toLowerCase())) {
+          clone.headers[k] = '***';
+        }
+      }
+    } else {
+      clone.headers = {};
+    }
+    if (
+      clone.body &&
+      this.payloadLimit > 0 &&
+      clone.body.length > this.payloadLimit
+    ) {
+      clone.body = clone.body.slice(0, this.payloadLimit);
+    }
+    return clone;
+  }
+}
+
+export default NetworkCapture;

--- a/src/scripts/httpCapture.js
+++ b/src/scripts/httpCapture.js
@@ -1,0 +1,136 @@
+// Captura de tráfego HTTP/HTTPS diretamente no processo
+// Mantido por Pexe (instagram: David.devloli)
+/* eslint-disable */
+
+'use strict';
+
+function enviar(tipo, dados) {
+  send(Object.assign({ type: tipo }, dados));
+}
+
+function headersToJson(headers) {
+  const out = {};
+  const names = headers.names();
+  for (let i = 0; i < names.size(); i++) {
+    const n = names.get(i);
+    out[n] = headers.get(n);
+  }
+  return out;
+}
+
+function bodyToString(body) {
+  try {
+    if (!body) return '';
+    const Buffer = Java.use('okio.Buffer');
+    const buffer = Buffer.$new();
+    body.writeTo(buffer);
+    return buffer.readUtf8();
+  } catch (e) {
+    return '';
+  }
+}
+
+Java.perform(function () {
+  // Hook em OkHttp
+  try {
+    const RealCall = Java.use('okhttp3.RealCall');
+    RealCall.execute.implementation = function () {
+      const execId = this.hashCode().toString();
+      const req = this.request();
+      const ts = Date.now();
+      enviar('http.request', {
+        execId,
+        ts,
+        pid: Process.id,
+        tid: Process.getCurrentThreadId(),
+        api: 'java',
+        lib: 'OkHttp',
+        url: req.url().toString(),
+        method: req.method(),
+        headers: headersToJson(req.headers()),
+        body: bodyToString(req.body()),
+        direction: 'out',
+      });
+      const res = this.execute();
+      enviar('http.response', {
+        execId,
+        ts: Date.now(),
+        pid: Process.id,
+        tid: Process.getCurrentThreadId(),
+        api: 'java',
+        lib: 'OkHttp',
+        status: res.code(),
+        headers: headersToJson(res.headers()),
+        body: bodyToString(res.body()),
+        direction: 'in',
+      });
+      return res;
+    };
+  } catch (e) {
+    // ignora se OkHttp não estiver presente
+  }
+
+  // Hook em HttpUrlConnection básico
+  try {
+    const HTTPSUrlConnection = Java.use('javax.net.ssl.HttpsURLConnection');
+    HTTPSUrlConnection.getInputStream.implementation = function () {
+      const execId = this.hashCode().toString();
+      enviar('http.request', {
+        execId,
+        ts: Date.now(),
+        pid: Process.id,
+        tid: Process.getCurrentThreadId(),
+        api: 'java',
+        lib: 'HttpUrlConnection',
+        url: this.getURL().toString(),
+        method: this.getRequestMethod(),
+        headers: {},
+        direction: 'out',
+      });
+      const stream = this.getInputStream();
+      enviar('http.response', {
+        execId,
+        ts: Date.now(),
+        pid: Process.id,
+        tid: Process.getCurrentThreadId(),
+        api: 'java',
+        lib: 'HttpUrlConnection',
+        status: this.getResponseCode(),
+        headers: {},
+        direction: 'in',
+      });
+      return stream;
+    };
+  } catch (e) {
+    // ignora
+  }
+});
+
+// Hook nativo em SSL_read / SSL_write
+['SSL_read', 'SSL_write'].forEach(function (name) {
+  const addr = Module.findExportByName(null, name);
+  if (!addr) return;
+  Interceptor.attach(addr, {
+    onEnter(args) {
+      this.buf = args[1];
+      this.len = args[2].toInt32();
+      this.execId = this.threadId + ':' + Date.now();
+      this.ts = Date.now();
+    },
+    onLeave(ret) {
+      const size = ret.toInt32();
+      if (size <= 0) return;
+      const data = Memory.readByteArray(this.buf, size);
+      enviar(name === 'SSL_write' ? 'http.request' : 'http.response', {
+        execId: this.execId,
+        ts: Date.now(),
+        pid: Process.id,
+        tid: this.threadId,
+        api: 'native',
+        lib: name,
+        body: data ? data.toString('utf8') : '',
+        direction: name === 'SSL_write' ? 'out' : 'in',
+      });
+    },
+  });
+});

--- a/tests/networkCapture.test.js
+++ b/tests/networkCapture.test.js
@@ -1,0 +1,44 @@
+import { NetworkCapture } from '../src/networkCapture.js';
+
+describe('NetworkCapture', () => {
+  test('mascara e calcula métricas', () => {
+    const cap = new NetworkCapture({
+      maskKeys: ['Authorization'],
+      payloadLimit: 10,
+    });
+    cap.addEvent({
+      type: 'http.request',
+      execId: '1',
+      ts: 0,
+      pid: 1,
+      tid: 1,
+      api: 'java',
+      lib: 'OkHttp',
+      url: 'https://exemplo',
+      method: 'GET',
+      headers: { Authorization: 'segredo', Foo: 'Bar' },
+      body: '123456789012345',
+      direction: 'out',
+    });
+    cap.addEvent({
+      type: 'http.response',
+      execId: '1',
+      ts: 100,
+      pid: 1,
+      tid: 1,
+      api: 'java',
+      lib: 'OkHttp',
+      status: 200,
+      headers: {},
+      direction: 'in',
+    });
+    const eventos = cap.events;
+    expect(eventos[0].headers.Authorization).toBe('***');
+    expect(eventos[0].body).toBe('1234567890');
+    const metrics = cap.getMetrics();
+    expect(metrics.total).toBe(1);
+    expect(metrics.errorRate).toBe(0);
+    expect(metrics.avg).toBe(100);
+    expect(metrics.p95).toBe(100);
+  });
+});


### PR DESCRIPTION
## Resumo
- adicionar DSL de eventos HTTP/HTTPS com agregador e métricas
- incluir script de hook para OkHttp, HttpUrlConnection e SSL_read/SSL_write
- documentar captura de rede no README

## Testes
- `npm run lint`
- `npm test`

Autor: Pexe (instagram: [@David.devloli](https://instagram.com/David.devloli))

------
https://chatgpt.com/codex/tasks/task_b_68aba457d27c8322a42db1f167b220e7