### PR TITLE
Isola módulos nativos com preload e IPC

### DIFF
--- a/main.cjs
+++ b/main.cjs
@@ -1,12 +1,39 @@
-const { app, BrowserWindow } = require('electron');
+// Autor: Pexe (instagram: @David.devloli)
+const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
+
+// Desativa aceleração de hardware para evitar problemas com GPU
+app.disableHardwareAcceleration();
+
+ipcMain.handle('devices:list', async () => {
+  const { listDevices, autoConnectEmulators } = await import('./src/adbService.js');
+  await autoConnectEmulators().catch(() => {});
+  return listDevices();
+});
+
+ipcMain.handle('adb:connect', async (_event, ip, port) => {
+  const { connectAdb } = await import('./src/adbService.js');
+  await connectAdb(ip, port);
+});
+
+ipcMain.handle('frida:ensure', async (_event, id) => {
+  const { ensureFrida } = await import('./src/fridaService.js');
+  await ensureFrida(id);
+});
+
+ipcMain.handle('frida:isRunning', async (_event, id) => {
+  const { isFridaRunning } = await import('./src/fridaService.js');
+  return isFridaRunning(id);
+});
 
 function createWindow() {
   const win = new BrowserWindow({
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true,
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
     },
   });
 

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,9 @@
+// Autor: Pexe (instagram: @David.devloli)
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('myAPI', {
+  listDevices: () => ipcRenderer.invoke('devices:list'),
+  connectAdb: (ip, port) => ipcRenderer.invoke('adb:connect', ip, port),
+  ensureFrida: (id) => ipcRenderer.invoke('frida:ensure', id),
+  isFridaRunning: (id) => ipcRenderer.invoke('frida:isRunning', id),
+});

--- a/src/renderer/components/Topbar.jsx
+++ b/src/renderer/components/Topbar.jsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { listDevices } from '../../adbService.js';
-import { isFridaRunning } from '../../fridaService.js';
 
 export default function Topbar({ onHistorico }) {
   const [adbOnline, setAdbOnline] = useState(false);
@@ -8,10 +6,12 @@ export default function Topbar({ onHistorico }) {
 
   useEffect(() => {
     const check = async () => {
-      const devices = await listDevices().catch(() => []);
+      const devices = await window.myAPI.listDevices().catch(() => []);
       setAdbOnline(devices.length > 0);
       if (devices.length > 0) {
-        const frida = await isFridaRunning(devices[0].id).catch(() => false);
+        const frida = await window.myAPI
+          .isFridaRunning(devices[0].id)
+          .catch(() => false);
         setFridaOnline(frida);
       } else {
         setFridaOnline(false);

--- a/src/renderer/pages/Dispositivos.jsx
+++ b/src/renderer/pages/Dispositivos.jsx
@@ -2,12 +2,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useToast } from '../components/ToastContext.jsx';
 import Titulo from '../components/Titulo.jsx';
-import {
-  listDevices,
-  connectAdb,
-  autoConnectEmulators,
-} from '../../adbService.js';
-import { ensureFrida } from '../../fridaService.js';
 
 export default function Dispositivos() {
   const toast = useToast();
@@ -18,8 +12,7 @@ export default function Dispositivos() {
   const [serialFilter, setSerialFilter] = useState('');
 
   const refreshDevices = useCallback(async () => {
-    await autoConnectEmulators().catch(() => {});
-    const list = await listDevices().catch(() => []);
+    const list = await window.myAPI.listDevices().catch(() => []);
     setDevices(list);
   }, []);
 
@@ -32,7 +25,7 @@ export default function Dispositivos() {
   const handleConnect = async () => {
     toast('carregando', 'Conectando...');
     try {
-      await connectAdb(ip, Number(port) || 5555);
+      await window.myAPI.connectAdb(ip, Number(port) || 5555);
       toast('sucesso', 'Conectado!');
       refreshDevices();
     } catch (e) {
@@ -108,7 +101,7 @@ export default function Dispositivos() {
                       onClick={async () => {
                         toast('carregando', 'Inicializando Frida...');
                         try {
-                          await ensureFrida(d.id);
+                          await window.myAPI.ensureFrida(d.id);
                           toast('sucesso', 'Frida iniciado');
                         } catch {
                           toast('erro', 'Falha no Frida');


### PR DESCRIPTION
## Resumo
- adiciona script de preload expondo APIs seguras para o renderer
- desativa nodeIntegration e aceleração de hardware no processo principal
- atualiza Dispositivos e Topbar para usar `window.myAPI`
