### PR TITLE
Aprimora contraste e espaçamento da interface

### DIFF
--- a/src/renderer/components/Sidebar.jsx
+++ b/src/renderer/components/Sidebar.jsx
@@ -16,7 +16,7 @@ export default function Sidebar({ current, onChange }) {
         {menus.map((m) => (
           <button
             key={m.key}
-            className={current === m.key ? 'active' : ''}
+            className={`btn btn-ghost ${current === m.key ? 'active' : ''}`}
             onClick={() => onChange(m.key)}
           >
             <span>{m.label}</span>

--- a/src/renderer/components/Titulo.jsx
+++ b/src/renderer/components/Titulo.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
 export default function Titulo({ children }) {
-  return <h2>{children}</h2>;
+  return <h2 className="titulo">{children}</h2>;
 }
 

--- a/src/renderer/components/Topbar.jsx
+++ b/src/renderer/components/Topbar.jsx
@@ -37,7 +37,7 @@ export default function Topbar({ onHistorico }) {
           Efeitos
           <input type="checkbox" />
         </label>
-        <button onClick={onHistorico} className="btn">
+        <button onClick={onHistorico} className="btn btn-ghost">
           Histórico
         </button>
       </div>

--- a/src/renderer/pages/Dispositivos.jsx
+++ b/src/renderer/pages/Dispositivos.jsx
@@ -42,7 +42,15 @@ export default function Dispositivos() {
   return (
     <div className="content">
       <Titulo>Dispositivos</Titulo>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+      <div
+        className="card"
+        style={{
+          display: 'flex',
+          gap: 'var(--espaco-sm)',
+          marginBottom: 'var(--espaco-md)',
+          flexWrap: 'wrap',
+        }}
+      >
         <input
           placeholder="IP"
           value={ip}
@@ -53,10 +61,20 @@ export default function Dispositivos() {
           value={port}
           onChange={(e) => setPort(e.target.value)}
         />
-        <button onClick={handleConnect}>Conectar ADB (TCP/IP)</button>
+        <button onClick={handleConnect} className="btn btn-primary">
+          Conectar ADB (TCP/IP)
+        </button>
       </div>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+      <div
+        className="card"
+        style={{
+          display: 'flex',
+          gap: 'var(--espaco-sm)',
+          marginBottom: 'var(--espaco-sm)',
+          flexWrap: 'wrap',
+        }}
+      >
         <input
           placeholder="Filtrar por modelo"
           value={modelFilter}
@@ -70,7 +88,7 @@ export default function Dispositivos() {
       </div>
 
       <div className="table-container">
-        <table>
+        <table className="tabela">
           <thead>
             <tr>
               <th>Modelo</th>
@@ -98,6 +116,7 @@ export default function Dispositivos() {
                   </td>
                   <td>
                     <button
+                      className="btn btn-primary"
                       onClick={async () => {
                         toast('carregando', 'Inicializando Frida...');
                         try {

--- a/src/renderer/pages/Execucao.jsx
+++ b/src/renderer/pages/Execucao.jsx
@@ -57,7 +57,15 @@ export default function Execucao() {
   return (
     <div className="content">
       <Titulo>Execução</Titulo>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '1rem' }}>
+      <div
+        className="card"
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 'var(--espaco-sm)',
+          marginBottom: 'var(--espaco-md)',
+        }}
+      >
         <select value={device} onChange={(e) => setDevice(e.target.value)}>
           {devices.map((d) => (
             <option key={d}>{d}</option>
@@ -70,28 +78,36 @@ export default function Execucao() {
             value={processQuery}
             onChange={(e) => setProcessQuery(e.target.value)}
           />
-          <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
+          <div
+            style={{ display: 'flex', gap: 'var(--espaco-xs)', flexWrap: 'wrap' }}
+          >
             {filteredProcesses.map((p) => (
-              <button key={p} type="button" onClick={() => addProcess(p)}>
+              <button
+                key={p}
+                type="button"
+                onClick={() => addProcess(p)}
+                className="btn btn-ghost"
+              >
                 {p}
               </button>
             ))}
           </div>
-          <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap', marginTop: '0.25rem' }}>
+          <div
+            style={{
+              display: 'flex',
+              gap: 'var(--espaco-xs)',
+              flexWrap: 'wrap',
+              marginTop: 'var(--espaco-xs)',
+            }}
+          >
             {selectedProcesses.map((p) => (
-              <span
-                key={p}
-                style={{
-                  padding: '0.25rem 0.5rem',
-                  background: '#eee',
-                  borderRadius: '16px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.25rem',
-                }}
-              >
+              <span key={p} className="chip">
                 {p}
-                <button type="button" onClick={() => removeProcess(p)}>
+                <button
+                  type="button"
+                  onClick={() => removeProcess(p)}
+                  className="btn btn-ghost"
+                >
                   x
                 </button>
               </span>
@@ -137,7 +153,13 @@ export default function Execucao() {
           )}
         </div>
 
-        <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--espaco-xs)',
+          }}
+        >
           <input
             type="checkbox"
             checked={spawn}
@@ -146,10 +168,10 @@ export default function Execucao() {
           Spawn
         </label>
 
-        <button onClick={start} disabled={running}>
+        <button onClick={start} disabled={running} className="btn btn-primary">
           Rodar
         </button>
-        <button onClick={stop} disabled={!running}>
+        <button onClick={stop} disabled={!running} className="btn btn-ghost">
           Parar
         </button>
       </div>

--- a/src/renderer/pages/Historico.jsx
+++ b/src/renderer/pages/Historico.jsx
@@ -41,7 +41,15 @@ export default function Historico() {
   return (
     <div className="content">
       <Titulo>Histórico</Titulo>
-      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.5rem' }}>
+      <div
+        className="card"
+        style={{
+          display: 'flex',
+          gap: 'var(--espaco-sm)',
+          flexWrap: 'wrap',
+          marginBottom: 'var(--espaco-sm)',
+        }}
+      >
         <select value={deviceFilter} onChange={(e) => setDeviceFilter(e.target.value)}>
           <option value="">Todos dispositivos</option>
           {[...new Set(data.map((d) => d.device))].map((d) => (
@@ -54,12 +62,20 @@ export default function Historico() {
             <option key={s}>{s}</option>
           ))}
         </select>
-        <input type="date" value={dateFilter} onChange={(e) => setDateFilter(e.target.value)} />
-        <button onClick={exportJSONL}>Exportar JSONL</button>
-        <button onClick={exportTXT}>Exportar TXT</button>
+        <input
+          type="date"
+          value={dateFilter}
+          onChange={(e) => setDateFilter(e.target.value)}
+        />
+        <button onClick={exportJSONL} className="btn btn-primary">
+          Exportar JSONL
+        </button>
+        <button onClick={exportTXT} className="btn btn-ghost">
+          Exportar TXT
+        </button>
       </div>
       <div className="table-container">
-        <table>
+        <table className="tabela">
           <thead>
             <tr>
               <th>Data</th>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -16,37 +16,38 @@ html, body, #root {
 }
 
 .sidebar {
-  background: var(--primary-color);
-  color: #fff;
+  background: var(--cor-superficie);
+  color: var(--cor-texto);
   display: flex;
   flex-direction: column;
 }
 
 .sidebar .brand {
-  padding: 1rem;
+  padding: var(--espaco-md);
   font-weight: bold;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--espaco-sm);
 }
 
 .sidebar nav {
   flex: 1;
 }
 
-.sidebar nav button {
+.sidebar nav .btn {
   display: block;
   width: 100%;
   background: none;
   border: none;
   color: inherit;
-  padding: 0.75rem 1rem;
+  padding: var(--espaco-sm) var(--espaco-md);
   text-align: left;
   cursor: pointer;
 }
 
-.sidebar nav button.active {
-  background: #444;
+.sidebar nav .btn.active {
+  background: var(--cor-primaria);
+  color: var(--cor-fundo);
 }
 
 .main {
@@ -55,16 +56,26 @@ html, body, #root {
 }
 
 .topbar {
-  background: #f5f5f5;
-  padding: 0.5rem 1rem;
+  background: var(--cor-superficie);
+  color: var(--cor-texto);
+  padding: var(--espaco-sm) var(--espaco-md);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
+  gap: var(--espaco-md);
+}
+.topbar .status {
+  display: flex;
+  gap: var(--espaco-md);
+}
+.topbar .acoes {
+  display: flex;
+  align-items: center;
+  gap: var(--espaco-sm);
 }
 
 .content {
-  padding: 1rem;
+  padding: var(--espaco-md);
   overflow: auto;
 }
 
@@ -108,7 +119,7 @@ html, body, #root {
   .app-grid {
     grid-template-columns: 60px 1fr;
   }
-  .sidebar nav button span {
+  .sidebar nav .btn span {
     display: none;
   }
 }

--- a/src/styles/componentes.css
+++ b/src/styles/componentes.css
@@ -7,6 +7,11 @@ body {
   margin: 0;
 }
 
+/* Títulos */
+.titulo {
+  color: var(--cor-texto);
+}
+
 /* Botões */
 .btn {
   padding: var(--espaco-sm) var(--espaco-md);
@@ -70,6 +75,7 @@ select {
 }
 .tabela th {
   background: var(--cor-superficie);
+  color: var(--cor-texto);
 }
 
 /* Toasters */


### PR DESCRIPTION
## Resumo
- Ajusta contraste de tabelas e títulos usando variáveis de cor
- Reorganiza filtros e painéis com `flex`, `gap` e classe `.card`
- Padroniza botões e espaçamento na topbar e sidebar
