### PR TITLE
Atualiza versão do Frida para 16.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "adbkit": "^2.11.1",
-        "frida": "^17.2.17",
+        "frida": "16.7.7",
         "prettier": "^2.8.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1648,27 +1648,6 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3555,7 +3534,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -5707,30 +5685,40 @@
       }
     },
     "node_modules/frida": {
-      "version": "17.2.17",
-      "resolved": "https://registry.npmjs.org/frida/-/frida-17.2.17.tgz",
-      "integrity": "sha512-riABZnsWUpue6jJ8BVgIbq59borzl6lp4CmZrAF2b0aw6B7yxhHGkmg3lZDs6Wbti0sKpHiPnTcU2X1eHhXSFg==",
+      "version": "16.7.7",
+      "resolved": "https://registry.npmjs.org/frida/-/frida-16.7.7.tgz",
+      "integrity": "sha512-R7yizZjSVIqi9R90T1ypsmN+ytSQ3qN18jFC4ml74qfIn5Z5NJ1jEU8zXyKRvXu1gGpuHJraIOxcGhemWzCQSw==",
       "hasInstallScript": true,
       "license": "LGPL-2.0 WITH WxWindows-exception-3.1",
       "dependencies": {
         "bindings": "^1.5.0",
-        "minimatch": "^10.0.1",
-        "prebuild-install": "^7.1.3"
+        "minimatch": "^9.0.3",
+        "nan": "^2.18.0",
+        "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/frida/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/frida/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8016,6 +8004,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sql.js": "^1.9.0",
-    "frida": "^17.2.17"
+    "frida": "16.7.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.0",

--- a/src/fridaService.js
+++ b/src/fridaService.js
@@ -10,7 +10,7 @@ async function loadNodeModule(name) {
   return mod.default || mod;
 }
 
-const FRIDA_VERSION = '17.2.17';
+const FRIDA_VERSION = '16.7.7';
 
 function readAll(stream) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Resumo
- define a versão padrão do Frida como 16.7.7 no serviço de integração
- ajusta dependências do projeto para usar o Frida 16.7.7

## Testes
- `npm test`
- `npm run lint`

Autor: Pexe (instagram: @David.devloli)

------
https://chatgpt.com/codex/tasks/task_b_68abd8562fb88322958a32362b46158d