### PR TITLE
feat: permitir configuracao do caminho do launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Mantido por **Pexe** (Instagram [@David.devloli](https://instagram.com/David.dev
 ## Pré-requisitos
 - Java 17 ou superior
 - Minecraft instalado com o mod Baritone
-- Launcher do Minecraft configurado no sistema ("minecraft-launcher" no PATH)
+- Launcher do Minecraft configurado no sistema ("minecraft-launcher" no PATH) ou caminho fornecido no `config.json`
 
 ## Como compilar
 ```bash
@@ -23,8 +23,9 @@ java -cp bin Main
 Edite o arquivo `config.json` para ajustar:
 - `minecraftVersion`: versão do jogo a ser carregada (ex: `"1.21"`).
 - `gameDir`: diretório de instalação do Minecraft.
+- `launcherPath`: caminho completo do executável do launcher (opcional se estiver no PATH).
 - `baritoneCommand`: comando a ser enviado após o carregamento do mundo (ex: `".mine diamond_ore"`).
 
 ## Observações
 - O tempo de espera para o carregamento do mundo pode ser ajustado em `BaritoneCommander.java`.
-- O caminho do launcher pode ser alterado em `LauncherHandler.java`.
+- Caso o launcher não esteja no PATH, informe seu caminho em `launcherPath` no `config.json`.

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "minecraftVersion": "1.21",
   "gameDir": "C:/Users/SeuUsuario/AppData/Roaming/.minecraft",
+  "launcherPath": "C:/Program Files/Minecraft Launcher/MinecraftLauncher.exe",
   "baritoneCommand": ".mine diamond_ore"
 }

--- a/src/ConfigReader.java
+++ b/src/ConfigReader.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
  * {
  *   "minecraftVersion": "1.21",
  *   "gameDir": "C:/caminho/do/minecraft",
+ *   "launcherPath": "C:/caminho/para/minecraft-launcher.exe",
  *   "baritoneCommand": ".mine diamond_ore"
  * }
  *
@@ -21,6 +22,7 @@ public class ConfigReader {
     public static class Config {
         public String minecraftVersion;
         public String gameDir;
+        public String launcherPath;
         public String baritoneCommand;
     }
 
@@ -32,6 +34,7 @@ public class ConfigReader {
         Config cfg = new Config();
         cfg.minecraftVersion = extract(json, "minecraftVersion");
         cfg.gameDir = extract(json, "gameDir");
+        cfg.launcherPath = extract(json, "launcherPath");
         cfg.baritoneCommand = extract(json, "baritoneCommand");
         return cfg;
     }

--- a/src/LauncherHandler.java
+++ b/src/LauncherHandler.java
@@ -3,7 +3,7 @@ import java.io.IOException;
 
 /**
  * Responsável por iniciar o launcher do Minecraft usando {@link ProcessBuilder}.
- * Ajuste o caminho do executável conforme necessário.
+ * Ajuste o caminho do executável conforme necessário via `launcherPath` no config.
  *
  * Autor: Pexe (Instagram @David.devloli)
  */
@@ -19,9 +19,11 @@ public class LauncherHandler {
      * parâmetro "gameDir" do arquivo de configuração.
      */
     public Process launch() throws IOException {
-        // Aqui assumimos que o executável "minecraft-launcher" está no PATH ou
-        // localizado dentro do diretório do jogo. Modifique se necessário.
-        ProcessBuilder pb = new ProcessBuilder("minecraft-launcher", "--workDir", config.gameDir,
+        // Usa o caminho configurado ou assume "minecraft-launcher" no PATH
+        String launcher = (config.launcherPath != null && !config.launcherPath.isBlank())
+                ? config.launcherPath
+                : "minecraft-launcher";
+        ProcessBuilder pb = new ProcessBuilder(launcher, "--workDir", config.gameDir,
                 "--version", config.minecraftVersion);
         pb.directory(new File(config.gameDir));
         return pb.start();


### PR DESCRIPTION
## Resumo
- tornar `launcherPath` configurável no `config.json`
- usar o caminho configurado ao iniciar o launcher do Minecraft
- documentar a nova opção no README
