### PR TITLE
Permitir configuração do caminho do launcher do Minecraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ java -cp bin Main
 Edite o arquivo `config.json` para ajustar:
 - `minecraftVersion`: versão do jogo a ser carregada (ex: `"1.21"`).
 - `gameDir`: diretório de instalação do Minecraft.
+- `launcherPath`: caminho completo para o executável do launcher (opcional; se vazio, usa-se `minecraft-launcher`).
 - `baritoneCommand`: comando a ser enviado após o carregamento do mundo (ex: `".mine diamond_ore"`).
 
 ## Observações

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "minecraftVersion": "1.21",
   "gameDir": "C:/Users/SeuUsuario/AppData/Roaming/.minecraft",
+  "launcherPath": "C:/Program Files/Minecraft Launcher/MinecraftLauncher.exe",
   "baritoneCommand": ".mine diamond_ore"
 }

--- a/src/ConfigReader.java
+++ b/src/ConfigReader.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
  * {
  *   "minecraftVersion": "1.21",
  *   "gameDir": "C:/caminho/do/minecraft",
+ *   "launcherPath": "C:/Program Files/Minecraft Launcher/MinecraftLauncher.exe",
  *   "baritoneCommand": ".mine diamond_ore"
  * }
  *
@@ -21,6 +22,7 @@ public class ConfigReader {
     public static class Config {
         public String minecraftVersion;
         public String gameDir;
+        public String launcherPath;
         public String baritoneCommand;
     }
 
@@ -32,6 +34,7 @@ public class ConfigReader {
         Config cfg = new Config();
         cfg.minecraftVersion = extract(json, "minecraftVersion");
         cfg.gameDir = extract(json, "gameDir");
+        cfg.launcherPath = extract(json, "launcherPath");
         cfg.baritoneCommand = extract(json, "baritoneCommand");
         return cfg;
     }

--- a/src/LauncherHandler.java
+++ b/src/LauncherHandler.java
@@ -16,12 +16,16 @@ public class LauncherHandler {
 
     /**
      * Inicia o launcher do Minecraft. O diretório de trabalho é definido pelo
-     * parâmetro "gameDir" do arquivo de configuração.
+     * parâmetro "gameDir" do arquivo de configuração. Caso o campo
+     * {@code launcherPath} esteja vazio, assume-se que o executável
+     * "minecraft-launcher" está no PATH do sistema.
      */
     public Process launch() throws IOException {
-        // Aqui assumimos que o executável "minecraft-launcher" está no PATH ou
-        // localizado dentro do diretório do jogo. Modifique se necessário.
-        ProcessBuilder pb = new ProcessBuilder("minecraft-launcher", "--workDir", config.gameDir,
+        String executable = config.launcherPath == null || config.launcherPath.isBlank()
+                ? "minecraft-launcher"
+                : config.launcherPath;
+
+        ProcessBuilder pb = new ProcessBuilder(executable, "--workDir", config.gameDir,
                 "--version", config.minecraftVersion);
         pb.directory(new File(config.gameDir));
         return pb.start();


### PR DESCRIPTION
## Resumo
- Adiciona campo `launcherPath` ao `config.json` para definir o executável do launcher.
- Usa o caminho configurado em `LauncherHandler` e atualiza a leitura em `ConfigReader`.
- Documenta a nova opção no `README`.

## Testes
- `javac -d bin src/*.java`
- `java -cp bin Main` *(falha esperada: No such file or directory para o launcher)*

------
https://chatgpt.com/codex/tasks/task_b_68b24c7856ec8322b8019b44ae86359e