### PR TITLE
feat: gerenciador de dispositivos ADB

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,8 @@ Repositório oficial do **Frida GUI Dashboard**, uma aplicação de desktop mult
 
 Para mais detalhes sobre objetivos, foco e público-alvo, consulte [docs/visao_geral.md](docs/visao_geral.md).
 
+## Recursos
+
+- Detecção automática de dispositivos ADB (USB e emuladores) com atualização em tempo real e cadastro de endpoints remotos.
+
 Autor: Pexe (Instagram: [@David.devloli](https://instagram.com/David.devloli))

--- a/core/device_manager.py
+++ b/core/device_manager.py
@@ -3,9 +3,121 @@
 Autor: Pexe (Instagram: @David.devloli)
 """
 
+from __future__ import annotations
+
+import asyncio
+from typing import Callable, Dict, List
+
+from .models import DeviceInfo, DeviceType
+
 
 class DeviceManager:
-    """Classe responsável por administrar dispositivos."""
+    """Classe responsável por administrar dispositivos.
 
-    def __init__(self) -> None:
-        pass
+    O gerenciamento é feito de forma assíncrona, consultando periodicamente o
+    comando ``adb devices`` sem bloquear a interface gráfica.
+    """
+
+    def __init__(self, interval: float = 2.0) -> None:
+        self._interval = interval
+        self._devices: Dict[str, DeviceInfo] = {}
+        self._remotes: Dict[str, DeviceInfo] = {}
+        self._listeners: List[Callable[[List[DeviceInfo]], None]] = []
+        self._task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # Controle de execução
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Inicia a tarefa de monitoramento de dispositivos."""
+
+        if self._task is None:
+            self._task = asyncio.create_task(self._poll_loop())
+
+    def stop(self) -> None:
+        """Interrompe o monitoramento de dispositivos."""
+
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    # ------------------------------------------------------------------
+    # Manipulação de listeners
+    # ------------------------------------------------------------------
+    def add_listener(self, callback: Callable[[List[DeviceInfo]], None]) -> None:
+        """Registra um callback chamado a cada atualização de dispositivos."""
+
+        self._listeners.append(callback)
+
+    def _emit(self) -> None:
+        devices = list(self._devices.values())
+        for remote in self._remotes.values():
+            if remote.id not in self._devices:
+                devices.append(remote)
+        for cb in self._listeners:
+            cb(devices)
+
+    # ------------------------------------------------------------------
+    # Dispositivos remotos
+    # ------------------------------------------------------------------
+    def add_remote_device(self, endpoint: str, notes: str = "") -> None:
+        """Adiciona um endpoint remoto apenas para registro."""
+
+        info = DeviceInfo(
+            id=endpoint,
+            name=notes or endpoint,
+            type=DeviceType.USB,
+            status="offline",
+        )
+        self._remotes[endpoint] = info
+        self._emit()
+
+    # ------------------------------------------------------------------
+    # Monitoramento
+    # ------------------------------------------------------------------
+    async def _poll_loop(self) -> None:
+        """Loop assíncrono que atualiza a lista de dispositivos."""
+
+        while True:
+            await self._update_devices()
+            await asyncio.sleep(self._interval)
+
+    async def _update_devices(self) -> None:
+        """Executa ``adb devices`` e atualiza os dispositivos encontrados."""
+
+        seen: Dict[str, DeviceInfo] = {}
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "adb",
+                "devices",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+            lines = stdout.decode().splitlines()[1:]
+        except FileNotFoundError:
+            lines = []
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            serial = parts[0]
+            status = parts[1] if len(parts) > 1 else "unknown"
+            dtype = (
+                DeviceType.EMULATOR
+                if serial.startswith("emulator-")
+                else DeviceType.USB
+            )
+            seen[serial] = DeviceInfo(
+                id=serial,
+                name=serial,
+                type=dtype,
+                status=status,
+            )
+
+        self._devices = seen
+        self._emit()
+

--- a/ui/widgets/device_panel.py
+++ b/ui/widgets/device_panel.py
@@ -3,16 +3,72 @@
 Autor: Pexe (Instagram: @David.devloli)
 """
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PyQt6.QtGui import QBrush, QColor
+from PyQt6.QtWidgets import (
+    QInputDialog,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QStyle,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.device_manager import DeviceManager
+from core.models import DeviceInfo, DeviceType
 
 
 class DevicePanel(QWidget):
-    """Exibe informações sobre dispositivos conectados."""
+    """Exibe e gerencia dispositivos conectados via ADB."""
 
     def __init__(self) -> None:
         super().__init__()
+
+        self._manager = DeviceManager()
+        self._manager.add_listener(self._refresh)
+        self._manager.start()
+
         layout = QVBoxLayout(self)
-        placeholder = QLabel("Painel de Dispositivos")
-        placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(placeholder)
+
+        self._add_btn = QPushButton("Adicionar dispositivo remoto (Android)")
+        self._add_btn.clicked.connect(self._add_remote_device)
+        layout.addWidget(self._add_btn)
+
+        self._list = QListWidget()
+        self._list.setUniformItemSizes(True)
+        layout.addWidget(self._list)
+
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
+    def _add_remote_device(self) -> None:
+        endpoint, ok = QInputDialog.getText(
+            self,
+            "Adicionar dispositivo remoto",
+            "Endpoint ADB (ex.: 192.168.0.10:5555)",
+        )
+        if not ok or not endpoint:
+            return
+        notes, _ = QInputDialog.getText(
+            self,
+            "Notas",
+            "Notas adicionais (opcional)",
+        )
+        self._manager.add_remote_device(endpoint, notes)
+
+    def _refresh(self, devices: list[DeviceInfo]) -> None:
+        self._list.clear()
+        for dev in devices:
+            item = QListWidgetItem(f"{dev.name} ({dev.id})")
+            item.setToolTip(dev.status or "")
+            color = QColor("green") if dev.status == "device" else QColor("gray")
+            item.setForeground(QBrush(color))
+
+            icon = (
+                self.style().standardIcon(QStyle.StandardPixmap.SP_ComputerIcon)
+                if dev.type == DeviceType.EMULATOR
+                else self.style().standardIcon(QStyle.StandardPixmap.SP_DriveHDIcon)
+            )
+            item.setIcon(icon)
+            self._list.addItem(item)
+


### PR DESCRIPTION
## Descrição
- monitora `adb devices` de forma assíncrona
- exibe dispositivos USB e emuladores em tempo real
- permite registrar endpoints remotos de Android
