### PR TITLE
Adiciona métricas de CPU/memória e visualizador JSON

### DIFF
--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -3,3 +3,24 @@
 Autor: Pexe (Instagram: @David.devloli)
 """
 
+from typing import Any, Callable, Dict
+
+_PARSERS: Dict[str, Callable[[bytes], Any]] = {}
+
+
+def register_parser(name: str, func: Callable[[bytes], Any]) -> None:
+    """Registra um ``func`` para decodificar dados identificados por ``name``."""
+
+    _PARSERS[name] = func
+
+
+def parse(name: str, data: bytes) -> Any:
+    """Executa o parser registrado para ``name``."""
+
+    if name not in _PARSERS:
+        raise KeyError(f"Parser não registrado: {name}")
+    return _PARSERS[name](data)
+
+
+__all__ = ["register_parser", "parse"]
+

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -49,8 +49,8 @@ class MainWindow(QMainWindow):
 
         # Direita inferior: abas de gráficos e JSON
         self.data_tabs = QTabWidget()
-        self.charts_panel = ChartsPanel()
-        self.json_viewer = JsonViewer()
+        self.charts_panel = ChartsPanel(self._bus)
+        self.json_viewer = JsonViewer(self._bus)
         self.data_tabs.addTab(self.charts_panel, "Gráficos")
         self.data_tabs.addTab(self.json_viewer, "JSON")
 

--- a/ui/widgets/charts_panel.py
+++ b/ui/widgets/charts_panel.py
@@ -3,16 +3,83 @@
 Autor: Pexe (Instagram: @David.devloli)
 """
 
+from __future__ import annotations
+
+import asyncio
+from typing import List, Optional
+
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import (
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+    QPushButton,
+)
+
+try:  # pragma: no cover - dependência opcional
+    import pyqtgraph as pg
+except Exception:  # pragma: no cover
+    pg = None
+
+from core.collectors import ProcessMetricsCollector
+from core.event_bus import EventBus
+from core.models import MetricSample
 
 
 class ChartsPanel(QWidget):
-    """Exibe gráficos utilizando pyqtgraph."""
+    """Exibe gráficos de CPU e memória do processo selecionado."""
 
-    def __init__(self) -> None:
+    def __init__(self, bus: EventBus) -> None:
         super().__init__()
+        self._bus = bus
+        self._pid: Optional[int] = None
+        self._collector: Optional[ProcessMetricsCollector] = None
+        self._cpu_data: List[float] = []
+        self._mem_data: List[float] = []
+        self._max_samples = 300
+
         layout = QVBoxLayout(self)
-        placeholder = QLabel("Gráficos")
-        placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(placeholder)
+
+        self._start_btn = QPushButton("Iniciar Métricas")
+        self._start_btn.clicked.connect(self._toggle_metrics)
+        layout.addWidget(self._start_btn)
+
+        if pg is None:
+            placeholder = QLabel("pyqtgraph não disponível")
+            placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            layout.addWidget(placeholder)
+        else:
+            self._cpu_plot = pg.PlotWidget(title="CPU %")
+            self._cpu_curve = self._cpu_plot.plot(pen="y")
+            self._mem_plot = pg.PlotWidget(title="Memória (MB)")
+            self._mem_curve = self._mem_plot.plot(pen="c")
+            layout.addWidget(self._cpu_plot)
+            layout.addWidget(self._mem_plot)
+            self._bus.metric_sample.connect(self._update_charts)
+
+    def set_process(self, pid: int) -> None:
+        """Define o PID do processo alvo."""
+
+        self._pid = pid
+
+    def _toggle_metrics(self) -> None:
+        if self._collector:
+            asyncio.create_task(self._collector.stop())
+            self._collector = None
+            self._start_btn.setText("Iniciar Métricas")
+            return
+        if self._pid is None:
+            return
+        self._collector = ProcessMetricsCollector(self._pid)
+        self._collector.start()
+        self._start_btn.setText("Parar Métricas")
+
+    def _update_charts(self, sample: MetricSample) -> None:
+        if pg is None or sample.process_pid != self._pid:
+            return
+        self._cpu_data.append(sample.cpu_pct)
+        self._mem_data.append(sample.rss_mb)
+        self._cpu_data = self._cpu_data[-self._max_samples :]
+        self._mem_data = self._mem_data[-self._max_samples :]
+        self._cpu_curve.setData(self._cpu_data)
+        self._mem_curve.setData(self._mem_data)

--- a/ui/widgets/json_viewer.py
+++ b/ui/widgets/json_viewer.py
@@ -3,16 +3,72 @@
 Autor: Pexe (Instagram: @David.devloli)
 """
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
+import json
+from typing import Any
+
+from PyQt6.QtWidgets import (
+    QTreeView,
+    QVBoxLayout,
+    QWidget,
+    QPlainTextEdit,
+)
+from PyQt6.QtGui import QStandardItemModel, QStandardItem
+
+from core.event_bus import EventBus
+from core.models import LogEvent
 
 
 class JsonViewer(QWidget):
-    """Exibe dados JSON formatados."""
+    """Exibe objetos JSON em árvore, com fallback para texto cru."""
 
-    def __init__(self) -> None:
+    def __init__(self, bus: EventBus) -> None:
         super().__init__()
+        self._bus = bus
+
         layout = QVBoxLayout(self)
-        placeholder = QLabel("Visualizador JSON")
-        placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        layout.addWidget(placeholder)
+        self._tree = QTreeView()
+        self._model = QStandardItemModel()
+        self._model.setHorizontalHeaderLabels(["Chave", "Valor"])
+        self._tree.setModel(self._model)
+
+        self._raw = QPlainTextEdit()
+        self._raw.setReadOnly(True)
+
+        layout.addWidget(self._tree)
+        layout.addWidget(self._raw)
+        self._raw.hide()
+
+        self._bus.log_event.connect(self._handle_log)
+
+    def _handle_log(self, event: LogEvent) -> None:
+        self.display_text(event.message)
+
+    def display_text(self, text: str) -> None:
+        """Tenta interpretar ``text`` como JSON e exibir em árvore."""
+
+        try:
+            data = json.loads(text)
+        except Exception:
+            self._tree.hide()
+            self._raw.show()
+            self._raw.setPlainText(text)
+            return
+
+        self._raw.hide()
+        self._tree.show()
+        self._model.removeRows(0, self._model.rowCount())
+        self._populate(self._model.invisibleRootItem(), data)
+
+    def _populate(self, parent: QStandardItem, value: Any) -> None:
+        if isinstance(value, dict):
+            for key, val in value.items():
+                key_item = QStandardItem(str(key))
+                val_item = QStandardItem("" if isinstance(val, (dict, list)) else str(val))
+                parent.appendRow([key_item, val_item])
+                self._populate(key_item, val)
+        elif isinstance(value, list):
+            for idx, val in enumerate(value):
+                key_item = QStandardItem(str(idx))
+                val_item = QStandardItem("" if isinstance(val, (dict, list)) else str(val))
+                parent.appendRow([key_item, val_item])
+                self._populate(key_item, val)


### PR DESCRIPTION
## Resumo
- Coletor de métricas de processo via `adb` com CPU% e RSS
- Painel de gráficos com pyqtgraph para CPU e memória
- Visualizador hierárquico de JSON e registro de parsers customizados

## Testes
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b3af39abac83229ba05dab91fbb123