### PR TITLE
Adicionar script de instalação de dependências

### DIFF
--- a/instalar_dependencias.sh
+++ b/instalar_dependencias.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Autor: Pexe (instagram: David.devloli)
+# Este script instala todas as dependências necessárias para o FridaDesk.
+
+set -e
+
+pip install \
+    PyQt6 \
+    qasync \
+    mitmproxy \
+    jinja2 \
+    pydantic \
+    pyqtgraph \
+    matplotlib \
+    ruff \
+    mypy \
+    pytest \
+    pyinstaller


### PR DESCRIPTION
## Resumo
- Adiciona script `instalar_dependencias.sh` para instalar todas as dependências do projeto.

## Testes
- `make lint` falhou devido a erros do mypy.
- `mypy --python-version 3.12 .` falhou com erros de tipos em módulos PyQt6.
- `make test` executado com sucesso.


------
https://chatgpt.com/codex/tasks/task_b_68b3c8b7ea2c8322860569d6508228e3