### PR TITLE
Corrige importação de QShortcut no painel de console

### DIFF
--- a/ui/widgets/console_panel.py
+++ b/ui/widgets/console_panel.py
@@ -6,14 +6,13 @@ Autor: Pexe (Instagram: @David.devloli)
 from datetime import datetime
 from typing import List
 
-from PyQt6.QtGui import QKeySequence
+from PyQt6.QtGui import QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QApplication,
     QHBoxLayout,
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QShortcut,
     QStyle,
     QTableWidget,
     QTableWidgetItem,


### PR DESCRIPTION
## Resumo
- Ajusta importação de **QShortcut** para utilizar `PyQt6.QtGui`
