### PR TITLE
Corrige execução assíncrona para mapeamento de dispositivos ADB

### DIFF
--- a/core/device_manager.py
+++ b/core/device_manager.py
@@ -32,7 +32,8 @@ class DeviceManager:
         """Inicia a tarefa de monitoramento de dispositivos."""
 
         if self._task is None:
-            self._task = asyncio.create_task(self._poll_loop())
+            loop = asyncio.get_event_loop()
+            self._task = loop.create_task(self._poll_loop())
 
     def stop(self) -> None:
         """Interrompe o monitoramento de dispositivos."""

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -22,11 +22,13 @@ class EventBus(QObject):
 
     def __init__(self) -> None:
         super().__init__()
-        self._queue: asyncio.Queue[Any] = asyncio.Queue()
+        self._queue: asyncio.Queue[Any] | None = None
 
     async def start(self) -> None:
         """Consome eventos da fila e emite sinais correspondentes."""
 
+        if self._queue is None:
+            self._queue = asyncio.Queue()
         while True:
             event = await self._queue.get()
             if isinstance(event, LogEvent):
@@ -40,6 +42,8 @@ class EventBus(QObject):
     def publish(self, event: Any) -> None:
         """Publica um novo evento no barramento."""
 
+        if self._queue is None:
+            self._queue = asyncio.Queue()
         self._queue.put_nowait(event)
 
 

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ async def simulate_logs() -> None:
         await asyncio.sleep(0.1)
 
 
-async def main() -> None:
+def main() -> None:
     """Função principal da aplicação."""
 
     app = QApplication(sys.argv)
@@ -40,18 +40,18 @@ async def main() -> None:
     asyncio.set_event_loop(loop)
 
     bus = get_event_bus()
-    asyncio.create_task(bus.start())
+    loop.create_task(bus.start())
 
     window = MainWindow(bus)
     load_plugins(window, bus)
     window.show()
 
-    asyncio.create_task(simulate_logs())
+    loop.create_task(simulate_logs())
 
     with loop:
-        await loop.run_forever()
+        loop.run_forever()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()
 


### PR DESCRIPTION
## Resumo
- Ajusta EventBus para criar fila somente com loop ativo
- Inicia monitoramento de dispositivos usando loop do Qt
- Refatora `main` para evitar `asyncio.run` e usar `loop.run_forever`

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b3cdd219c08322bf9ac63d2f406020