### PR TITLE
Adicionar gerenciador Frida com suporte a scripts

### DIFF
--- a/core/frida_manager.py
+++ b/core/frida_manager.py
@@ -1,0 +1,82 @@
+"""Integração central com Frida.
+
+Autor: Pexe (Instagram: @David.devloli)
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import frida  # type: ignore[import]
+
+from .event_bus import publish
+from .models import LogEvent
+
+
+class FridaManager:
+    """Gerencia a comunicação com processos via Frida."""
+
+    def __init__(self) -> None:
+        self._session: Any | None = None
+        self._script: Any | None = None
+
+    # ------------------------------------------------------------------
+    # Conexão
+    # ------------------------------------------------------------------
+    def attach(self, target: int | str) -> None:
+        """Anexa ao processo especificado por PID ou nome."""
+
+        self._session = frida.attach(target)
+
+    def detach(self) -> None:
+        """Desanexa do processo atual e descarrega o script."""
+
+        if self._script is not None:
+            try:
+                self._script.unload()
+            except Exception:  # pragma: no cover - falhas ao descarregar
+                pass
+            self._script = None
+        if self._session is not None:
+            try:
+                self._session.detach()
+            except Exception:  # pragma: no cover - falhas ao desanexar
+                pass
+            self._session = None
+
+    # ------------------------------------------------------------------
+    # Scripts
+    # ------------------------------------------------------------------
+    def inject_script_from_text(self, source: str) -> None:
+        """Carrega e injeta um script a partir de ``source``."""
+
+        if self._session is None:
+            raise RuntimeError("Sessão não iniciada")
+
+        self._script = self._session.create_script(source)
+        self._script.on("message", self._on_message)
+        self._script.load()
+
+    def inject_script_from_file(self, path: str | Path) -> None:
+        """Lê um arquivo e injeta seu conteúdo como script."""
+
+        code = Path(path).read_text(encoding="utf-8")
+        self.inject_script_from_text(code)
+
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
+    def _on_message(self, message: Any, data: Any) -> None:
+        payload = (
+            message.get("payload") if isinstance(message, dict) else message
+        )
+        event = LogEvent(
+            ts=time.time(),
+            level="info",
+            tag="frida",
+            message=str(payload),
+            raw=str(message),
+        )
+        publish(event)

--- a/tests/test_frida_manager.py
+++ b/tests/test_frida_manager.py
@@ -1,0 +1,91 @@
+"""Testes para o FridaManager.
+
+Autor: Pexe (Instagram: @David.devloli)
+"""
+
+from pathlib import Path
+import types
+
+import importlib
+import sys
+
+from core import event_bus
+from core.models import LogEvent
+
+
+class FakeScript:
+    """Script falso que dispara uma mensagem ao carregar."""
+
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+        self._cb = None
+
+    def on(self, _event: str, callback) -> None:  # pragma: no cover - assinatura simplificada
+        self._cb = callback
+
+    def load(self) -> None:
+        if self._cb:
+            self._cb({"type": "send", "payload": self._payload}, None)
+
+    def unload(self) -> None:  # pragma: no cover - sem efeitos
+        pass
+
+
+class FakeSession:
+    """Sessão falsa utilizada para testes."""
+
+    def __init__(self) -> None:
+        self.detached = False
+
+    def create_script(self, code: str) -> FakeScript:
+        payload = code.split("'")[1] if "'" in code else code
+        return FakeScript(payload)
+
+    def detach(self) -> None:
+        self.detached = True
+
+
+def make_fake_frida_module() -> types.ModuleType:
+    """Cria um módulo ``frida`` simplificado."""
+
+    module = types.ModuleType("frida")
+    module.attach = lambda target: FakeSession()
+    return module
+
+
+def get_manager(monkeypatch):
+    fake = make_fake_frida_module()
+    monkeypatch.setitem(sys.modules, "frida", fake)
+    import core.frida_manager as fm
+    importlib.reload(fm)
+    return fm.FridaManager()
+
+
+def test_inject_script_from_text(monkeypatch) -> None:
+    eventos: list[LogEvent] = []
+    monkeypatch.setattr(event_bus, "publish", lambda e: eventos.append(e))
+    manager = get_manager(monkeypatch)
+    manager.attach(1234)
+    manager.inject_script_from_text("send('ola')")
+
+    assert len(eventos) == 1
+    assert eventos[0].message == "ola"
+
+    manager.detach()
+    assert manager._session is None
+
+
+def test_inject_script_from_file(monkeypatch, tmp_path: Path) -> None:
+    eventos: list[LogEvent] = []
+    monkeypatch.setattr(event_bus, "publish", lambda e: eventos.append(e))
+    manager = get_manager(monkeypatch)
+
+    arquivo = tmp_path / "script.js"
+    arquivo.write_text("send('arquivo')", encoding="utf-8")
+
+    manager.attach("nome")
+    manager.inject_script_from_file(arquivo)
+
+    assert len(eventos) == 1
+    assert eventos[0].message == "arquivo"
+


### PR DESCRIPTION
## Resumo
- implementar FridaManager para anexar processos, injetar scripts e repassar mensagens ao EventBus
- incluir testes cobrindo injeção por texto e arquivo


