### PR TITLE
feat: habilita comunicação bidirecional com scripts Frida

### DIFF
--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -19,6 +19,8 @@ class EventBus(QObject):
     log_event = pyqtSignal(object)
     metric_sample = pyqtSignal(object)
     network_event = pyqtSignal(object)
+    frida_message_received = pyqtSignal(object)
+    frida_send_to_script = pyqtSignal(object)
 
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
## Resumo
- Adiciona sinais específicos de mensagens no EventBus
- Permite enviar dados ao script injetado via FridaManager
- Acrescenta campo e botão para envio de mensagens no editor de scripts
- Cobre fluxo de mensagens nos testes do FridaManager
