### PR TITLE
Adicionar botão de verificação do Frida no painel de dispositivos

### DIFF
--- a/core/process_manager.py
+++ b/core/process_manager.py
@@ -53,3 +53,22 @@ class ProcessManager(QObject):
             processes.append(ProcessInfo(pid=pid, name=name, user=user))
 
         self.processes_ready.emit(processes)
+
+    async def check_frida(self, device: DeviceInfo) -> bool:
+        """Verifica se o Frida está disponível no ``device``."""
+
+        if ":" in device.id:
+            cmd = ["frida-ps", "-R"]
+        else:
+            cmd = ["frida-ps", "-U"]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate()
+            return proc.returncode == 0
+        except FileNotFoundError:
+            return False


### PR DESCRIPTION
## Resumo
- adicionar método para checar presença do Frida
- incluir botão "Verificar Frida" no painel de dispositivos
- criar testes para a nova verificação

## Testes
- `ruff check .`
- `make lint` *(falhou: Item "None" of "QStatusBar | None" has no attribute "showMessage")*
- `make test`

Autor: Pexe (Instagram: @David.devloli)

------
https://chatgpt.com/codex/tasks/task_b_68b77af59c508322b2200900fdad2517