### PR TITLE
Reinicia servidor ADB antes de listar dispositivos

### DIFF
--- a/core/device_manager.py
+++ b/core/device_manager.py
@@ -86,7 +86,18 @@ class DeviceManager:
             await asyncio.sleep(self._interval)
 
     async def _update_devices(self) -> None:
-        """Executa ``adb devices`` e atualiza os dispositivos encontrados."""
+        """Reinicia o servidor ADB e atualiza os dispositivos encontrados."""
+
+        try:
+            kill_proc = await asyncio.create_subprocess_exec(
+                "adb",
+                "kill-server",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await kill_proc.communicate()
+        except FileNotFoundError:
+            pass
 
         await self._connect_known_emulators()
         seen: Dict[str, DeviceInfo] = {}


### PR DESCRIPTION
## Resumo
- Reinicia o servidor ADB automaticamente antes de consultar os dispositivos
