### PR TITLE
Ampliar varredura de portas ADB para emuladores

### DIFF
--- a/core/device_manager.py
+++ b/core/device_manager.py
@@ -24,7 +24,28 @@ class DeviceManager:
         self._remotes: Dict[str, DeviceInfo] = {}
         self._listeners: List[Callable[[List[DeviceInfo]], None]] = []
         self._task: asyncio.Task | None = None
-        self._known_ports: Tuple[int, ...] = (5555, 62001, 21503)
+        self._known_ports: Tuple[int, ...] = self._generate_known_ports()
+
+    @staticmethod
+    def _generate_known_ports() -> Tuple[int, ...]:
+        """Gera faixas de portas ADB comuns em emuladores.
+
+        Inclui variações para múltiplas instâncias dos principais
+        emuladores do mercado.
+        """
+
+        ports: list[int] = []
+
+        # BlueStacks/LDPlayer/Genymotion: 5555, 5557, 5559, ...
+        ports.extend(range(5555, 5585, 2))
+
+        # Nox Player: 62001, 62003, ...
+        ports.extend(range(62001, 62051, 2))
+
+        # MEmu: 21503, 21513, ...
+        ports.extend(range(21503, 21553, 10))
+
+        return tuple(ports)
 
     # ------------------------------------------------------------------
     # Controle de execução

--- a/docs/portas_emuladores.md
+++ b/docs/portas_emuladores.md
@@ -14,6 +14,11 @@ Este documento resume as portas mais comuns utilizadas por emuladores Android e 
 | **Android Studio (AVD)** | 5554/5555 | O console usa porta par (ex.: `5554`) e o ADB usa a porta ímpar seguinte (`5555`). |
 
 O `DeviceManager` tenta conectar automaticamente às portas listadas acima para localizar emuladores em execução no host.
+Além disso, o sistema varre faixas dessas portas para cobrir múltiplas instâncias:
+
+- `5555`–`5583` (incremento de `2`) para **BlueStacks**, **LDPlayer** e **Genymotion**;
+- `62001`–`62049` (incremento de `2`) para **Nox Player**;
+- `21503`–`21543` (incremento de `10`) para **MEmu**.
 
 ## Portas relacionadas ao ADB
 

--- a/tests/test_device_manager_ports.py
+++ b/tests/test_device_manager_ports.py
@@ -1,0 +1,25 @@
+"""Testes para portas padrão do DeviceManager.
+
+Autor: Pexe (Instagram: @David.devloli)
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+# ruff: noqa: E402
+
+from core.device_manager import DeviceManager
+
+
+def test_known_port_ranges_cover_common_emulators():
+    dm = DeviceManager()
+    ports = dm._known_ports
+    # BlueStacks/LDPlayer/Genymotion
+    assert 5555 in ports and 5557 in ports
+    # Nox Player
+    assert 62001 in ports and 62003 in ports
+    # MEmu
+    assert 21503 in ports and 21513 in ports


### PR DESCRIPTION
## Resumo
- Expandida a lista de portas padrão para detectar múltiplas instâncias de emuladores ADB
- Documentadas as faixas de portas varridas automaticamente pelo DeviceManager
