### PR TITLE
Adicionar suporte ao CodeShare

### DIFF
--- a/core/codeshare.py
+++ b/core/codeshare.py
@@ -1,0 +1,61 @@
+"""Utilidades para carregar scripts do CodeShare.
+
+Autor: Pexe (Instagram: @David.devloli)
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.request
+from typing import Optional
+
+
+_CODESHARE_RAW_URL = "https://frida.codeshare.io/{slug}.js"
+
+
+def extract_codeshare_slug(text: str) -> Optional[str]:
+    """Extrai o identificador ``autor/script`` a partir de ``text``.
+
+    Aceita comandos completos (``frida --codeshare autor/script``), URLs ou
+    apenas o próprio identificador.
+    """
+
+    text = text.strip()
+    if not text:
+        return None
+
+    # Remove prompt inicial "$" se existir
+    if text.startswith("$"):
+        text = text[1:].strip()
+
+    # Busca padrão --codeshare
+    match = re.search(r"--codeshare\s+([\w\-./@]+)", text)
+    if match:
+        text = match.group(1)
+
+    # Remove protocolo e domínio de URLs conhecidos
+    text = re.sub(
+        r"^(https?://)?(frida\.codeshare\.io|codeshare\.frida\.re)/@?",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    )
+
+    # Remove possíveis parâmetros e versões
+    text = text.split("?")[0]
+    parts = [p for p in text.split("/") if p]
+    if len(parts) < 2:
+        return None
+    return "/".join(parts[:2])
+
+
+def download_codeshare_script(identifier: str) -> str:
+    """Baixa o script correspondente a ``identifier`` do CodeShare."""
+
+    slug = extract_codeshare_slug(identifier)
+    if slug is None:
+        raise ValueError("Identificador CodeShare inválido")
+    url = _CODESHARE_RAW_URL.format(slug=slug)
+    req = urllib.request.Request(url, headers={"User-Agent": "FridaDesk"})
+    with urllib.request.urlopen(req) as response:  # nosec - URL controlada
+        return response.read().decode("utf-8")

--- a/core/frida_manager.py
+++ b/core/frida_manager.py
@@ -13,6 +13,7 @@ import frida  # type: ignore[import]
 
 from .event_bus import get_event_bus, publish
 from .models import LogEvent
+from .codeshare import download_codeshare_script
 
 
 class FridaManager:
@@ -65,6 +66,12 @@ class FridaManager:
         """Lê um arquivo e injeta seu conteúdo como script."""
 
         code = Path(path).read_text(encoding="utf-8")
+        self.inject_script_from_text(code)
+
+    def inject_script_from_codeshare(self, identifier: str) -> None:
+        """Baixa um snippet do CodeShare e o injeta."""
+
+        code = download_codeshare_script(identifier)
         self.inject_script_from_text(code)
 
     def send_message(self, payload: Any) -> None:

--- a/tests/test_codeshare.py
+++ b/tests/test_codeshare.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+import urllib.request
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.codeshare import extract_codeshare_slug, download_codeshare_script
+
+
+class FakeResponse:
+    def __init__(self, data: str) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data.encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_extract_slug_variants():
+    cmd = "frida --codeshare user/script -f target"
+    cmd2 = "$ frida --codeshare user/script -f target"
+    url = "https://frida.codeshare.io/user/script"
+    assert extract_codeshare_slug(cmd) == "user/script"
+    assert extract_codeshare_slug(cmd2) == "user/script"
+    assert extract_codeshare_slug(url) == "user/script"
+
+
+def test_download(monkeypatch):
+    def fake_urlopen(req):
+        assert req.full_url == "https://frida.codeshare.io/user/script.js"
+        return FakeResponse("send('ok')")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    code = download_codeshare_script("user/script")
+    assert code == "send('ok')"


### PR DESCRIPTION
## Resumo
- permitir download e injeção de scripts pelo CodeShare
- adicionar botão CodeShare ao editor de scripts com detecção automática
- incluir testes para parsing e download de snippets
