### PR TITLE
Suporte a carregamento automático de scripts do CodeShare

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,7 @@ Para mais detalhes sobre objetivos, foco e público-alvo, consulte [docs/visao_g
 ## Recursos
 
 - Detecção automática de dispositivos ADB (USB e emuladores) com atualização em tempo real e cadastro de endpoints remotos.
+- Carregamento automático de scripts do CodeShare ao colar comandos
+  `frida --codeshare autor/script` no editor de scripts.
 
 Autor: Pexe (Instagram: [@David.devloli](https://instagram.com/David.devloli))


### PR DESCRIPTION
## Resumo
- detectar comandos `frida --codeshare` e baixar o código correspondente
- permitir carregamento automático no editor de scripts
- documentar uso de CodeShare no README

## Testes
- `make lint` *(falhou: Item "None" of "QListWidgetItem | None" has no attribute "text"  [union-attr])* 
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68b7b15b3e4483228bd0268a65f53b61