### PR TITLE
Revamp panel layout and enforce private-only interactions

### DIFF
--- a/src/panel/index.html
+++ b/src/panel/index.html
@@ -13,22 +13,108 @@
     <link rel="stylesheet" href="/panel/style.css" />
   </head>
   <body>
-    <header class="topbar">
-      <div class="topbar__brand">
-        <h1>CRM CCA · Painel de Atendimento</h1>
-        <span class="topbar__subtitle">Central de relacionamento em tempo real</span>
-      </div>
-      <div class="topbar__actions">
-        <button id="openSettings" type="button" class="button">Configurações</button>
-        <label class="switch" for="autoRefresh">
-          <input type="checkbox" id="autoRefresh" checked />
-          <span class="switch__label">Auto atualizar</span>
-        </label>
-        <button id="refreshTasks" type="button" class="button button--primary">Atualizar agora</button>
-        <span id="lastUpdate" class="last-update">Última atualização: --</span>
-      </div>
-    </header>
-    <main>
+    <div class="app-shell">
+      <aside class="sidebar">
+        <div class="sidebar__brand">
+          <span class="sidebar__logo" aria-hidden="true">FD</span>
+          <div>
+            <strong>FridaDesk</strong>
+            <small>Central Omnichannel</small>
+          </div>
+        </div>
+        <nav class="sidebar__nav" aria-label="Navegação principal">
+          <div class="sidebar__group">
+            <span class="sidebar__group-title">Gerência</span>
+            <ul>
+              <li class="is-active">
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">📊</span>
+                  <span>Dashboard</span>
+                </button>
+              </li>
+              <li>
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">📑</span>
+                  <span>Relatórios</span>
+                </button>
+              </li>
+              <li>
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">🧭</span>
+                  <span>Painéis</span>
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div class="sidebar__group">
+            <span class="sidebar__group-title">Comunicação</span>
+            <ul>
+              <li>
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">💬</span>
+                  <span>Atendimentos</span>
+                </button>
+              </li>
+              <li>
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">⚡</span>
+                  <span>Respostas rápidas</span>
+                </button>
+              </li>
+              <li>
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">🏷️</span>
+                  <span>Tags e campanhas</span>
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div class="sidebar__group">
+            <span class="sidebar__group-title">Administração</span>
+            <ul>
+              <li>
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">⚙️</span>
+                  <span>Configurações</span>
+                </button>
+              </li>
+              <li>
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">🔌</span>
+                  <span>Integrações</span>
+                </button>
+              </li>
+              <li>
+                <button type="button" class="sidebar__link">
+                  <span class="sidebar__icon" aria-hidden="true">📂</span>
+                  <span>Arquivos</span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </nav>
+        <footer class="sidebar__footer">
+          <span>© 2024 FridaDesk</span>
+          <span>v1.0</span>
+        </footer>
+      </aside>
+      <div class="app-shell__main">
+        <header class="topbar">
+          <div class="topbar__brand">
+            <h1>CRM CCA · Painel de Atendimento</h1>
+            <span class="topbar__subtitle">Central de relacionamento em tempo real</span>
+          </div>
+          <div class="topbar__actions">
+            <button id="openSettings" type="button" class="button">Configurações</button>
+            <label class="switch" for="autoRefresh">
+              <input type="checkbox" id="autoRefresh" checked />
+              <span class="switch__label">Auto atualizar</span>
+            </label>
+            <button id="refreshTasks" type="button" class="button button--primary">Atualizar agora</button>
+            <span id="lastUpdate" class="last-update">Última atualização: --</span>
+          </div>
+        </header>
+        <main>
       <section class="summary" id="summary"></section>
 
       <section class="runtime" id="runtimeStatus">
@@ -83,6 +169,16 @@
       </section>
 
       <section class="controls">
+        <div class="controls__header">
+          <div>
+            <h2>Painel de atendimentos</h2>
+            <p>Monitore a fila, refine por tags e mantenha o foco no que é prioritário.</p>
+          </div>
+          <div class="controls__actions">
+            <button id="resetFilters" type="button" class="button button--ghost">Limpar filtros</button>
+            <button type="button" class="button button--primary">Filtrar</button>
+          </div>
+        </div>
         <div class="controls__search">
           <input
             type="search"
@@ -100,9 +196,15 @@
             <span class="filter-group__label">Categorias</span>
             <div id="categoryFilters" class="filter-chips"></div>
           </div>
+        </div>
+        <div class="controls__toggles">
           <label class="toggle" for="showCompleted">
             <input type="checkbox" id="showCompleted" />
             <span>Mostrar concluídos</span>
+          </label>
+          <label class="toggle" for="filterPrivate">
+            <input type="checkbox" id="filterPrivate" checked />
+            <span>Somente conversas privadas</span>
           </label>
         </div>
         <div class="controls__view">
@@ -118,7 +220,9 @@
         <section id="board" class="board"></section>
         <aside id="insights" class="insights"></aside>
       </div>
-    </main>
+        </main>
+      </div>
+    </div>
 
     <div id="settingsOverlay" class="settings-overlay" aria-hidden="true">
       <section class="settings-panel" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">

--- a/src/panel/style.css
+++ b/src/panel/style.css
@@ -12,6 +12,10 @@
   --warning: #f59e0b;
   --danger: #dc2626;
   --info: #0ea5e9;
+  --sidebar-bg: #0b1120;
+  --sidebar-muted: rgba(226, 232, 240, 0.7);
+  --accent-purple: #8b5cf6;
+  --accent-teal: #14b8a6;
   --radius-lg: 18px;
   --radius-md: 12px;
   --radius-sm: 8px;
@@ -28,13 +32,139 @@ body {
   color: var(--text);
 }
 
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.app-shell__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 260px;
+  background: var(--sidebar-bg);
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.75rem 1.5rem;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  box-shadow: inset -1px 0 0 rgba(148, 163, 184, 0.12);
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.sidebar__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.6), rgba(139, 92, 246, 0.6));
+  color: #fff;
+  font-weight: 700;
+}
+
+.sidebar__brand small {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--sidebar-muted);
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  font-size: 0.9rem;
+}
+
+.sidebar__group-title {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  color: var(--sidebar-muted);
+  margin-bottom: 0.6rem;
+  display: block;
+}
+
+.sidebar__nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.sidebar__nav li {
+  color: rgba(226, 232, 240, 0.8);
+  border-radius: 12px;
+}
+
+.sidebar__link {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sidebar__link:focus-visible {
+  outline: 2px solid rgba(148, 163, 184, 0.6);
+  outline-offset: 2px;
+}
+
+.sidebar__nav li:hover .sidebar__link {
+  background: rgba(148, 163, 184, 0.12);
+  color: #fff;
+}
+
+.sidebar__nav li.is-active .sidebar__link {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(139, 92, 246, 0.35));
+  color: #fff;
+}
+
+.sidebar__icon {
+  font-size: 1.1rem;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--sidebar-muted);
+}
+
 .topbar {
   background: #0f172a;
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.5rem 2.25rem;
+  padding: 1.5rem clamp(1.5rem, 4vw, 3rem);
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.2);
   position: sticky;
   top: 0;
@@ -103,50 +233,177 @@ body {
 
 main {
   padding: 2.5rem clamp(1.5rem, 4vw, 3rem) 4rem;
+  flex: 1;
+  max-width: 1200px;
+  margin: 0 auto 4rem;
+  width: min(1200px, 100%);
 }
 
 .summary {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
   margin-bottom: 2.5rem;
 }
 
 .summary-card {
   background: var(--card-bg);
-  border: 1px solid var(--border);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: var(--radius-lg);
-  padding: 1.5rem 1.6rem;
-  box-shadow: 0 22px 45px var(--shadow);
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
+  padding: 1.5rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.1rem;
+  align-items: center;
   position: relative;
   overflow: hidden;
 }
 
-.summary-card::after {
+.summary-card::before {
   content: '';
   position: absolute;
-  inset: auto 1.2rem 0 1.2rem;
-  height: 4px;
-  border-radius: 999px;
-  background: var(--primary);
-  opacity: 0.15;
+  inset: 0;
+  opacity: 0.18;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.25), transparent 65%);
+  pointer-events: none;
 }
 
-.summary-card strong {
-  font-size: 2rem;
+.summary-card__icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: rgba(37, 99, 235, 0.15);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.65rem;
+  z-index: 1;
 }
 
-.summary-card span {
-  font-size: 0.95rem;
+.summary-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  position: relative;
+  z-index: 1;
+}
+
+.summary-card__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.summary-card__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
   color: var(--muted);
 }
 
-.summary-card small {
-  color: var(--primary);
+.summary-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
   font-weight: 600;
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--muted);
+}
+
+.summary-card__value {
+  font-size: 2.1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.summary-card__value.is-text {
+  font-size: 1.3rem;
+}
+
+.summary-card__detail {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.summary-card[data-type='active'] {
+  border-color: rgba(37, 99, 235, 0.35);
+}
+
+.summary-card[data-type='active'] .summary-card__icon {
+  background: rgba(37, 99, 235, 0.2);
+  color: #1d4ed8;
+}
+
+.summary-card[data-type='done'] {
+  border-color: rgba(22, 163, 74, 0.35);
+}
+
+.summary-card[data-type='done']::before {
+  background: linear-gradient(135deg, rgba(22, 163, 74, 0.25), transparent 65%);
+}
+
+.summary-card[data-type='done'] .summary-card__icon {
+  background: rgba(22, 163, 74, 0.18);
+  color: #15803d;
+}
+
+.summary-card[data-type='new']::before {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.25), transparent 65%);
+}
+
+.summary-card[data-type='new'] .summary-card__icon {
+  background: rgba(14, 165, 233, 0.2);
+  color: #0e7490;
+}
+
+.summary-card[data-type='alert'] {
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
+.summary-card[data-type='alert']::before {
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.28), transparent 65%);
+}
+
+.summary-card[data-type='alert'] .summary-card__icon {
+  background: rgba(245, 158, 11, 0.2);
+  color: #b45309;
+}
+
+.summary-card[data-type='private'] {
+  border-color: rgba(139, 92, 246, 0.35);
+}
+
+.summary-card[data-type='private']::before {
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.28), transparent 65%);
+}
+
+.summary-card[data-type='private'] .summary-card__icon {
+  background: rgba(139, 92, 246, 0.2);
+  color: #6d28d9;
+}
+
+.summary-card[data-type='integration']::before {
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.28), transparent 65%);
+}
+
+.summary-card[data-type='integration'] .summary-card__icon {
+  background: rgba(20, 184, 166, 0.18);
+  color: #0f766e;
+}
+
+.summary-card[data-type='whatsapp']::before {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.28), transparent 65%);
+}
+
+.summary-card[data-type='whatsapp'] .summary-card__icon {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
 }
 
 .runtime {
@@ -338,6 +595,24 @@ main {
   color: var(--muted);
 }
 
+@media (max-width: 1024px) {
+  .sidebar {
+    display: none;
+  }
+
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .app-shell__main {
+    min-height: auto;
+  }
+
+  .topbar {
+    border-radius: 0;
+  }
+}
+
 @media (max-width: 768px) {
   .runtime-card__body {
     flex-direction: column;
@@ -351,6 +626,19 @@ main {
     width: 100%;
     max-width: 260px;
   }
+
+  .controls__header {
+    align-items: flex-start;
+  }
+
+  .controls__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .controls__actions .button {
+    flex: 1 1 auto;
+  }
 }
 
 .controls {
@@ -362,6 +650,49 @@ main {
   padding: 1.5rem 1.75rem;
   margin-bottom: 2rem;
   box-shadow: 0 18px 40px var(--shadow);
+}
+
+.controls__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.controls__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.controls__header p {
+  margin: 0.4rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.controls__actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.controls__actions .button--ghost {
+  color: var(--muted);
+  border-color: rgba(15, 23, 42, 0.12);
+  background: rgba(15, 23, 42, 0.03);
+  box-shadow: none;
+}
+
+.controls__actions .button--ghost:hover {
+  background: rgba(37, 99, 235, 0.08);
+  border-color: rgba(37, 99, 235, 0.3);
+  color: var(--text);
+}
+
+.controls__actions .button--primary {
+  box-shadow: 0 16px 34px rgba(37, 99, 235, 0.3);
 }
 
 .controls__search input {
@@ -380,6 +711,13 @@ main {
 }
 
 .controls__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: center;
+}
+
+.controls__toggles {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem 1.5rem;
@@ -720,6 +1058,12 @@ main {
   color: #fff;
 }
 
+.task-actions button:disabled {
+  background: rgba(15, 23, 42, 0.1);
+  color: var(--muted);
+  cursor: not-allowed;
+}
+
 .task-actions .task-complete {
   background: var(--success);
   color: #fff;
@@ -727,6 +1071,21 @@ main {
 
 .task-actions .task-complete:hover {
   background: #15803d;
+}
+
+.task-card[data-origin='group'] {
+  border-color: rgba(14, 165, 233, 0.35);
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.08), rgba(14, 165, 233, 0.02));
+}
+
+.task-card[data-origin='group'] .badge--id {
+  background: rgba(14, 165, 233, 0.16);
+  border-color: rgba(14, 165, 233, 0.3);
+  color: #0369a1;
+}
+
+.task-number--group {
+  color: #0369a1;
 }
 
 .task-card--warning {
@@ -825,6 +1184,17 @@ main {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
+}
+
+.settings-panel .button--ghost {
+  color: var(--muted);
+  border-color: rgba(15, 23, 42, 0.12);
+}
+
+.settings-panel .button--ghost:hover {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--primary);
+  border-color: rgba(37, 99, 235, 0.3);
 }
 
 .settings-panel__header h2 {


### PR DESCRIPTION
## Summary
- add a persistent navigation sidebar, enhanced filter header, and a private conversations toggle to the panel markup
- refresh dashboard styling with new summary cards, updated control actions, and visual cues for group-originated tickets
- update panel logic to map contact details, default to private-only filtering, and surface richer summary metrics and insights
- ignore WhatsApp group messages while replying with category "portas de atendimento" suggestions to guide contacts

## Testing
- npm run lint


