### PR TITLE
Add cross-env to support Windows development script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "ws": "^8.17.0"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "eslint": "^8.57.0"
       }
     },
@@ -769,6 +770,25 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "NODE_ENV=development node src/index.js",
+    "dev": "cross-env NODE_ENV=development node src/index.js",
     "lint": "eslint ."
   },
   "keywords": [
@@ -28,6 +28,7 @@
     "ws": "^8.17.0"
   },
   "devDependencies": {
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.0",
+    "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- update the dev script to use cross-env so the NODE_ENV value is set consistently on Windows
- add the cross-env dependency and update the lockfile
